### PR TITLE
fix: resolve AttributeError in repo preferences and replace deprecated datetime.utcnow()

### DIFF
--- a/contribai/core/models.py
+++ b/contribai/core/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 
 from pydantic import BaseModel, Field
@@ -168,7 +168,7 @@ class Contribution(BaseModel):
     commit_message: str = ""
     tests_added: list[FileChange] = Field(default_factory=list)
     branch_name: str = ""
-    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     @property
     def total_files_changed(self) -> int:
@@ -183,7 +183,7 @@ class PRResult(BaseModel):
     pr_number: int
     pr_url: str
     status: PRStatus = PRStatus.OPEN
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     branch_name: str = ""
     fork_full_name: str = ""
 

--- a/contribai/generator/engine.py
+++ b/contribai/generator/engine.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 
 from contribai.core.config import ContributionConfig
 from contribai.core.models import (
@@ -79,7 +79,7 @@ class ContributionGenerator:
                 changes=changes,
                 commit_message=commit_msg,
                 branch_name=branch_name,
-                generated_at=datetime.utcnow(),
+                generated_at=datetime.now(UTC),
             )
 
             # 6: Self-review
@@ -108,7 +108,7 @@ class ContributionGenerator:
         if not self._memory:
             return None
         try:
-            return await self._memory.get_repo_preferences(context.full_name)
+            return await self._memory.get_repo_preferences(context.repo.full_name)
         except Exception as e:
             logger.debug("Could not fetch repo preferences: %s", e)
             return None

--- a/contribai/orchestrator/memory.py
+++ b/contribai/orchestrator/memory.py
@@ -7,7 +7,7 @@ to avoid duplicate work and improve over time.
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import aiosqlite
@@ -120,7 +120,7 @@ class Memory:
             """INSERT OR REPLACE INTO analyzed_repos
                (full_name, language, stars, analyzed_at, findings)
                VALUES (?, ?, ?, ?, ?)""",
-            (full_name, language, stars, datetime.utcnow().isoformat(), findings_count),
+            (full_name, language, stars, datetime.now(UTC).isoformat(), findings_count),
         )
         await self._db.commit()
 
@@ -146,7 +146,7 @@ class Memory:
         fork: str = "",
     ):
         """Record a submitted PR."""
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(UTC).isoformat()
         await self._db.execute(
             """INSERT OR REPLACE INTO submitted_prs
                (repo, pr_number, pr_url, title, type, branch, fork, created_at, updated_at)
@@ -159,7 +159,7 @@ class Memory:
         """Update PR status."""
         await self._db.execute(
             "UPDATE submitted_prs SET status = ?, updated_at = ? WHERE repo = ? AND pr_number = ?",
-            (status, datetime.utcnow().isoformat(), repo, pr_number),
+            (status, datetime.now(UTC).isoformat(), repo, pr_number),
         )
         await self._db.commit()
 
@@ -180,7 +180,7 @@ class Memory:
 
     async def get_today_pr_count(self) -> int:
         """Get number of PRs created today."""
-        today = datetime.utcnow().date().isoformat()
+        today = datetime.now(UTC).date().isoformat()
         cursor = await self._db.execute(
             "SELECT COUNT(*) FROM submitted_prs WHERE created_at LIKE ?",
             (f"{today}%",),
@@ -204,7 +204,7 @@ class Memory:
         """Record the start of a pipeline run. Returns run ID."""
         cursor = await self._db.execute(
             "INSERT INTO run_log (started_at) VALUES (?)",
-            (datetime.utcnow().isoformat(),),
+            (datetime.now(UTC).isoformat(),),
         )
         await self._db.commit()
         return cursor.lastrowid
@@ -223,7 +223,7 @@ class Memory:
                SET finished_at = ?, repos_analyzed = ?, prs_created = ?,
                    findings = ?, errors = ?
                WHERE id = ?""",
-            (datetime.utcnow().isoformat(), repos_analyzed, prs_created, findings, errors, run_id),
+            (datetime.now(UTC).isoformat(), repos_analyzed, prs_created, findings, errors, run_id),
         )
         await self._db.commit()
 
@@ -283,7 +283,7 @@ class Memory:
                 outcome,
                 feedback,
                 time_to_close_hours,
-                datetime.utcnow().isoformat(),
+                datetime.now(UTC).isoformat(),
             ),
         )
         await self._db.commit()
@@ -330,7 +330,7 @@ class Memory:
                 json.dumps(list(set(rejected_types))),
                 round(merge_rate, 3),
                 round(avg_hours, 1),
-                datetime.utcnow().isoformat(),
+                datetime.now(UTC).isoformat(),
             ),
         )
         await self._db.commit()


### PR DESCRIPTION
## Summary

- **Fix `AttributeError`**: `context.full_name` → `context.repo.full_name` in `generator/engine.py:111`. `RepoContext` doesn't have a `full_name` attribute — it lives on the nested `Repository` object. This silently prevented repo preferences from being loaded, degrading contribution quality for repos with prior PR history.
- **Replace deprecated `datetime.utcnow()`**: 11 occurrences across `core/models.py`, `generator/engine.py`, and `orchestrator/memory.py` replaced with `datetime.now(UTC)`. `utcnow()` was deprecated in Python 3.12 and produced 40 deprecation warnings in the test suite.

## Test plan

- [x] All 356 tests pass
- [x] Deprecation warnings reduced from 40 to 1 (remaining one is from pytest internals)
- [x] `ruff check` passes with no issues
- [x] Verified `RepoContext` model lacks `full_name` attr — only `repo: Repository` which has it