### PR TITLE
Quality: Insecure Webhook Handling

### DIFF
--- a/python/web/webhooks.py
+++ b/python/web/webhooks.py
@@ -48,12 +48,15 @@ async def github_webhook(request: Request):
         return JSONResponse({"error": "Payload too large"}, status_code=413)
 
     # Verify signature
-    if _webhook_secret:
-        signature = request.headers.get("X-Hub-Signature-256", "")
-        if not verify_webhook_signature(body, signature, _webhook_secret):
-            logger.warning("Invalid webhook signature")
-            # Bug 1 fix: use JSONResponse so FastAPI returns HTTP 403, not 200
-            return JSONResponse({"error": "Invalid signature"}, status_code=403)
+    if not _webhook_secret:
+        logger.error("Webhook secret not configured")
+        return JSONResponse({"error": "Webhook secret not configured"}, status_code=500)
+
+    signature = request.headers.get("X-Hub-Signature-256", "")
+    if not verify_webhook_signature(body, signature, _webhook_secret):
+        logger.warning("Invalid webhook signature")
+        # Bug 1 fix: use JSONResponse so FastAPI returns HTTP 403, not 200
+        return JSONResponse({"error": "Invalid signature"}, status_code=403)
 
     # Parse event
     event_type = request.headers.get("X-GitHub-Event", "")


### PR DESCRIPTION
## Problem

The webhook receiver processes incoming GitHub events even if no secret is configured. If `_webhook_secret` is empty, the signature verification is skipped entirely, allowing anyone to trigger the pipeline by sending unauthenticated POST requests to the `/api/webhooks/github` endpoint.

**Severity**: `high`
**File**: `python/web/webhooks.py`

## Solution

Enforce that a webhook secret must be configured in production environments. If the secret is missing, the endpoint should return a 500 error or refuse to process the request rather than defaulting to an insecure state.

## Changes

- `python/web/webhooks.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
