### PR TITLE
Quality: Fail-Open Self-Review Gate

### DIFF
--- a/crates/contribai-rs/src/generator/self_review.rs
+++ b/crates/contribai-rs/src/generator/self_review.rs
@@ -11,8 +11,8 @@ impl ContributionGenerator<'_> {
     /// Have the LLM review the generated contribution and approve or reject it.
     ///
     /// Builds a unified diff for modified files and asks the LLM whether the
-    /// change is correct. Defaults to `true` (approved) on LLM failures to
-    /// avoid blocking contributions on transient errors.
+    /// change is correct. Defaults to `false` (rejected) on LLM failures to
+    /// ensure a fail-closed posture.
     pub(crate) async fn self_review(
         &self,
         contribution: &Contribution,
@@ -81,8 +81,8 @@ impl ContributionGenerator<'_> {
                 approved
             }
             Err(e) => {
-                warn!(error = %e, "Self-review LLM call failed, approving by default");
-                true
+                warn!(error = %e, "Self-review LLM call failed, rejecting by default");
+                false
             }
         }
     }


### PR DESCRIPTION
## Problem

In the Rust implementation of the contribution generator, if the LLM call for self-review fails (e.g., due to a timeout, rate limit, or API error), the system logs a warning and approves the contribution by default. This bypasses a critical safety gate intended to prevent buggy or low-quality code from being submitted as a PR.

**Severity**: `medium`
**File**: `crates/contribai-rs/src/generator/self_review.rs`

## Solution

Change the default behavior to 'reject' (false) on LLM failure. This ensures a 'fail-closed' security posture where only explicitly reviewed and approved code is submitted.

## Changes

- `crates/contribai-rs/src/generator/self_review.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
