### PR TITLE
feat(discovery): add watchlist mode for targeted repo sweeps

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,10 +54,20 @@ discovery:
     - python
     - javascript
     - typescript
+    - rust
   stars_range: [50, 10000]
   min_last_activity_days: 30
   require_contributing_guide: false
   topics: []
+  # Watchlist: specific repos to sweep with `contribai watchlist`
+  # Skips discovery — runs targeted analysis on each repo in order.
+  # Format: "owner/repo"
+  watchlist: []
+  # Example:
+  # watchlist:
+  #   - "myorg/backend-api"
+  #   - "myorg/frontend-app"
+  #   - "myorg/infra-tools"
 
 storage:
   db_path: "~/.contribai/memory.db"

--- a/crates/contribai-rs/src/cli/mod.rs
+++ b/crates/contribai-rs/src/cli/mod.rs
@@ -81,6 +81,13 @@ enum Commands {
         dry_run: bool,
     },
 
+    /// Sweep all repositories in the watchlist (config.discovery.watchlist)
+    Watchlist {
+        /// Dry run — analyze but don't submit PRs
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Start MCP server for Claude/Antigravity integration
     McpServer,
 
@@ -437,6 +444,93 @@ impl Cli {
                         cleaned.to_string().red()
                     );
                 }
+                Ok(())
+            }
+
+            Commands::Watchlist { dry_run } => {
+                print_banner();
+                let config = load_config(self.config.as_deref())?;
+
+                let watchlist = &config.discovery.watchlist;
+                if watchlist.is_empty() {
+                    println!(
+                        "{} No repositories in watchlist. Add repos to config.yaml under discovery.watchlist:",
+                        "⚠️".yellow()
+                    );
+                    println!();
+                    println!("  discovery:");
+                    println!("    watchlist:");
+                    println!("      - \"owner/repo\"");
+                    println!("      - \"myorg/myproject\"");
+                    return Ok(());
+                }
+
+                println!(
+                    "📋 Watchlist sweep: {} repo(s) {}",
+                    watchlist.len().to_string().cyan().bold(),
+                    if dry_run {
+                        "(DRY RUN)".yellow().to_string()
+                    } else {
+                        "(LIVE)".green().to_string()
+                    }
+                );
+                println!();
+
+                let github = create_github(&config)?;
+                let llm = create_llm(&config)?;
+                let memory = create_memory(&config)?;
+                let event_bus = contribai::core::events::EventBus::default();
+
+                let pipeline = contribai::orchestrator::pipeline::ContribPipeline::new(
+                    &config,
+                    &github,
+                    llm.as_ref(),
+                    &memory,
+                    &event_bus,
+                );
+
+                let mut total_findings = 0usize;
+                let mut total_prs = 0usize;
+
+                for (i, repo_ref) in watchlist.iter().enumerate() {
+                    let parts: Vec<&str> = repo_ref.splitn(2, '/').collect();
+                    if parts.len() != 2 {
+                        println!(
+                            "  {} Skipping invalid entry: {} (expected \"owner/repo\")",
+                            "⚠️".yellow(),
+                            repo_ref.red()
+                        );
+                        continue;
+                    }
+                    let (owner, name) = (parts[0], parts[1]);
+
+                    println!(
+                        "  [{}/{}] 🎯 {}",
+                        (i + 1).to_string().cyan(),
+                        watchlist.len(),
+                        repo_ref.bold()
+                    );
+
+                    match pipeline.run_targeted(owner, name, dry_run).await {
+                        Ok(result) => {
+                            total_findings += result.findings_total;
+                            total_prs += result.prs_created;
+                            println!(
+                                "         {} findings, {} PRs",
+                                result.findings_total, result.prs_created
+                            );
+                        }
+                        Err(e) => {
+                            println!("         {} {}", "Error:".red(), e);
+                        }
+                    }
+                    println!();
+                }
+
+                println!("📊 Watchlist complete: {} total findings, {} PRs submitted",
+                    total_findings.to_string().cyan().bold(),
+                    total_prs.to_string().green().bold(),
+                );
                 Ok(())
             }
 

--- a/crates/contribai-rs/src/core/config.rs
+++ b/crates/contribai-rs/src/core/config.rs
@@ -385,6 +385,12 @@ pub struct DiscoveryConfig {
     pub stars_max: i64,
     #[serde(default = "default_disc_max_results")]
     pub max_results: usize,
+    /// Watchlist of specific repositories to analyze instead of discovering.
+    /// Each entry is "owner/repo" (e.g., "myorg/myproject").
+    /// When non-empty, `contribai watchlist` iterates these repos
+    /// using the targeted pipeline instead of search-based discovery.
+    #[serde(default)]
+    pub watchlist: Vec<String>,
 }
 
 fn default_disc_languages() -> Vec<String> {
@@ -423,6 +429,7 @@ impl Default for DiscoveryConfig {
             stars_min: default_disc_stars_min(),
             stars_max: default_disc_stars_max(),
             max_results: default_disc_max_results(),
+            watchlist: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `watchlist` field to `DiscoveryConfig` — a list of `"owner/repo"` strings for repos you want to sweep regularly
- Adds a new `contribai watchlist` CLI command that iterates the watchlist, running `run_targeted()` on each repo
- Supports `--dry-run` for analysis-only mode
- Gracefully handles per-repo errors without aborting the full sweep
- Aggregates findings and PR counts across all repos

## Motivation

ContribAI's existing `target` command works great for single repos, and `hunt` mode discovers repos via GitHub search. But there's a gap: **running ContribAI against your own repos on a schedule**.

With `watchlist`, you can:
```yaml
discovery:
  watchlist:
    - "myorg/backend-api"
    - "myorg/frontend-app"
    - "myorg/infra-tools"
```

Then schedule `contribai watchlist` via cron for continuous automated code review across your portfolio — security scans, code quality, docs — without relying on discovery.

## Test plan

- [ ] `contribai watchlist` with empty watchlist shows helpful config instructions
- [ ] `contribai watchlist --dry-run` iterates repos and reports findings without submitting PRs
- [ ] Invalid entries (missing `/`) are skipped with a warning
- [ ] Per-repo errors don't abort the sweep
- [ ] Final summary shows aggregated findings and PR counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)