### PR TITLE
Support custom base_url for openai and anthropic endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ Cargo.lock
 contribai-*.exe
 contribai-v*
 tmp_*.md
+
+# Powershell
+_*.ps1

--- a/crates/contribai-rs/src/cli/config_editor.rs
+++ b/crates/contribai-rs/src/cli/config_editor.rs
@@ -33,6 +33,11 @@ pub const KNOWN_KEYS: &[KeyDef] = &[
         valid_values: None,
     },
     KeyDef {
+        key: "llm.base_url",
+        description: "Custom endpoint URL (for OpenAI/Anthropic-compatible APIs)",
+        valid_values: None,
+    },
+    KeyDef {
         key: "llm.vertex_project",
         description: "Vertex AI GCP project ID",
         valid_values: None,

--- a/crates/contribai-rs/src/cli/mod.rs
+++ b/crates/contribai-rs/src/cli/mod.rs
@@ -1819,7 +1819,7 @@ async fn run_login_check(config_path: Option<&str>) -> anyhow::Result<()> {
                     .interact()?;
                 let choice = LlmChoice::from_index(provider_idx);
 
-                let (api_key, vertex_project) = match choice {
+                let (api_key, base_url, vertex_project) = match choice {
                     LlmChoice::VertexAi => {
                         println!(
                             "  {}",
@@ -1829,14 +1829,20 @@ async fn run_login_check(config_path: Option<&str>) -> anyhow::Result<()> {
                             .with_prompt("Google Cloud Project ID")
                             .default(std::env::var("GOOGLE_CLOUD_PROJECT").unwrap_or_default())
                             .interact_text()?;
-                        (String::new(), proj)
+                        (String::new(), String::new(), proj)
                     }
                     LlmChoice::Ollama => {
                         println!(
                             "  {}",
                             style("Make sure Ollama is running: https://ollama.ai").dim()
                         );
-                        (String::new(), String::new())
+                        let default_url = "http://localhost:11434";
+                        let url: String = Input::new()
+                            .with_prompt("Ollama base URL")
+                            .default(default_url.into())
+                            .interact_text()
+                            .unwrap_or_else(|_| default_url.into());
+                        (String::new(), url, String::new())
                     }
                     _ => {
                         let env_hint = match choice {
@@ -1849,11 +1855,26 @@ async fn run_login_check(config_path: Option<&str>) -> anyhow::Result<()> {
                             "  {}",
                             style(format!("Get your key at: {}", env_hint)).dim()
                         );
+                        let default_url = match choice {
+                            LlmChoice::OpenAi => "https://api.openai.com/v1",
+                            LlmChoice::Anthropic => "https://api.anthropic.com/v1",
+                            _ => "",
+                        };
+                        let base_url: String = if default_url.is_empty() {
+                            String::new()
+                        } else {
+                            Input::new()
+                                .with_prompt(format!("{} base URL (optional)", choice.provider_name()))
+                                .default(default_url.into())
+                                .allow_empty(true)
+                                .interact_text()
+                                .unwrap_or_default()
+                        };
                         let key: String = Password::new()
                             .with_prompt(format!("{} API Key (hidden)", choice.provider_name()))
                             .allow_empty_password(true)
                             .interact()?;
-                        (key, String::new())
+                        (key, base_url, String::new())
                     }
                 };
 
@@ -1877,6 +1898,8 @@ async fn run_login_check(config_path: Option<&str>) -> anyhow::Result<()> {
                         *line = format!("  model: \"{}\"", choice.default_model());
                     } else if trimmed.starts_with("api_key:") {
                         *line = format!("  api_key: \"{}\"", api_key);
+                    } else if trimmed.starts_with("base_url:") {
+                        *line = format!("  base_url: \"{}\"", base_url);
                     } else if trimmed.starts_with("vertex_project:") {
                         *line = format!("  vertex_project: \"{}\"", vertex_project);
                     }

--- a/crates/contribai-rs/src/cli/mod.rs
+++ b/crates/contribai-rs/src/cli/mod.rs
@@ -1864,7 +1864,10 @@ async fn run_login_check(config_path: Option<&str>) -> anyhow::Result<()> {
                             String::new()
                         } else {
                             Input::new()
-                                .with_prompt(format!("{} base URL (optional)", choice.provider_name()))
+                                .with_prompt(format!(
+                                    "{} base URL (optional)",
+                                    choice.provider_name()
+                                ))
                                 .default(default_url.into())
                                 .allow_empty(true)
                                 .interact_text()

--- a/crates/contribai-rs/src/cli/wizard.rs
+++ b/crates/contribai-rs/src/cli/wizard.rs
@@ -149,7 +149,15 @@ pub fn run_init_wizard(output_path: Option<&Path>) -> anyhow::Result<Option<Wiza
                 .allow_empty_password(true)
                 .interact()?;
             let api_key = if key.is_empty() { None } else { Some(key) };
-            (api_key, if base_url.trim().is_empty() { None } else { Some(base_url) }, None)
+            (
+                api_key,
+                if base_url.trim().is_empty() {
+                    None
+                } else {
+                    Some(base_url)
+                },
+                None,
+            )
         }
         LlmChoice::Anthropic => {
             println!(
@@ -167,7 +175,15 @@ pub fn run_init_wizard(output_path: Option<&Path>) -> anyhow::Result<Option<Wiza
                 .allow_empty_password(true)
                 .interact()?;
             let api_key = if key.is_empty() { None } else { Some(key) };
-            (api_key, if base_url.trim().is_empty() { None } else { Some(base_url) }, None)
+            (
+                api_key,
+                if base_url.trim().is_empty() {
+                    None
+                } else {
+                    Some(base_url)
+                },
+                None,
+            )
         }
         LlmChoice::Ollama => {
             println!(
@@ -180,7 +196,11 @@ pub fn run_init_wizard(output_path: Option<&Path>) -> anyhow::Result<Option<Wiza
                 .default(default_url.into())
                 .interact_text()
                 .unwrap_or_else(|_| default_url.into());
-            let base_url = if url.trim().is_empty() { None } else { Some(url) };
+            let base_url = if url.trim().is_empty() {
+                None
+            } else {
+                Some(url)
+            };
             (None, base_url, None)
         }
     };
@@ -317,11 +337,7 @@ fn print_wizard_summary(
         println!("  {:<20} {}", style("API Key:").dim(), style(masked).cyan());
     }
     if let Some(u) = base_url {
-        println!(
-            "  {:<20} {}",
-            style("Base URL:").dim(),
-            style(u).cyan()
-        );
+        println!("  {:<20} {}", style("Base URL:").dim(), style(u).cyan());
     }
     if let Some(p) = vertex_project {
         println!(
@@ -443,7 +459,10 @@ fn apply_wizard_to_yaml(yaml: &str, result: &WizardResult) -> String {
     if !has_base_url {
         let val = result.base_url.as_deref().unwrap_or("");
         let insert = format!("  base_url: \"{}\"", val);
-        if let Some(i) = lines.iter().position(|l| l.trim_start().starts_with("api_key:")) {
+        if let Some(i) = lines
+            .iter()
+            .position(|l| l.trim_start().starts_with("api_key:"))
+        {
             lines.insert(i + 1, insert);
         }
     }
@@ -620,7 +639,9 @@ mod tests {
         assert!(updated.contains("base_url: \"https://api.anthropic.com/v1\""));
         // base_url inserted after api_key
         let api_key_pos = updated.find("api_key: \"sk-new\"").unwrap();
-        let base_url_pos = updated.find("base_url: \"https://api.anthropic.com/v1\"").unwrap();
+        let base_url_pos = updated
+            .find("base_url: \"https://api.anthropic.com/v1\"")
+            .unwrap();
         assert!(base_url_pos > api_key_pos);
     }
 

--- a/crates/contribai-rs/src/cli/wizard.rs
+++ b/crates/contribai-rs/src/cli/wizard.rs
@@ -73,6 +73,7 @@ pub enum GithubAuthChoice {
 pub struct WizardResult {
     pub provider: LlmChoice,
     pub api_key: Option<String>,
+    pub base_url: Option<String>,
     pub vertex_project: Option<String>,
     pub github_token: Option<String>,
     pub max_prs_per_day: u32,
@@ -109,7 +110,7 @@ pub fn run_init_wizard(output_path: Option<&Path>) -> anyhow::Result<Option<Wiza
 
     // ── Step 2: Provider credentials ─────────────────────────────────────────
     println!("{}", style("Step 2/4 — Credentials").yellow().bold());
-    let (api_key, vertex_project) = match provider {
+    let (api_key, base_url, vertex_project) = match provider {
         LlmChoice::GeminiApiKey => {
             println!(
                 "  {}",
@@ -119,7 +120,7 @@ pub fn run_init_wizard(output_path: Option<&Path>) -> anyhow::Result<Option<Wiza
                 .with_prompt("Gemini API Key (hidden)")
                 .allow_empty_password(true)
                 .interact()?;
-            (if key.is_empty() { None } else { Some(key) }, None)
+            (if key.is_empty() { None } else { Some(key) }, None, None)
         }
         LlmChoice::VertexAi => {
             println!(
@@ -130,36 +131,57 @@ pub fn run_init_wizard(output_path: Option<&Path>) -> anyhow::Result<Option<Wiza
                 .with_prompt("Google Cloud Project ID")
                 .default(std::env::var("GOOGLE_CLOUD_PROJECT").unwrap_or_default())
                 .interact_text()?;
-            (None, if proj.is_empty() { None } else { Some(proj) })
+            (None, None, if proj.is_empty() { None } else { Some(proj) })
         }
         LlmChoice::OpenAi => {
             println!(
                 "  {}",
                 style("Get your key at: https://platform.openai.com/api-keys").dim()
             );
+            let base_url: String = Input::new()
+                .with_prompt("OpenAI-compatible base URL (optional)")
+                .default("https://api.openai.com/v1".into())
+                .allow_empty(true)
+                .interact_text()
+                .unwrap_or_default();
             let key: String = Password::new()
                 .with_prompt("OpenAI API Key (hidden)")
                 .allow_empty_password(true)
                 .interact()?;
-            (if key.is_empty() { None } else { Some(key) }, None)
+            let api_key = if key.is_empty() { None } else { Some(key) };
+            (api_key, if base_url.trim().is_empty() { None } else { Some(base_url) }, None)
         }
         LlmChoice::Anthropic => {
             println!(
                 "  {}",
                 style("Get your key at: https://console.anthropic.com/").dim()
             );
+            let base_url: String = Input::new()
+                .with_prompt("Anthropic-compatible base URL (optional)")
+                .default("https://api.anthropic.com/v1".into())
+                .allow_empty(true)
+                .interact_text()
+                .unwrap_or_default();
             let key: String = Password::new()
                 .with_prompt("Anthropic API Key (hidden)")
                 .allow_empty_password(true)
                 .interact()?;
-            (if key.is_empty() { None } else { Some(key) }, None)
+            let api_key = if key.is_empty() { None } else { Some(key) };
+            (api_key, if base_url.trim().is_empty() { None } else { Some(base_url) }, None)
         }
         LlmChoice::Ollama => {
             println!(
                 "  {}",
                 style("Make sure Ollama is running: https://ollama.ai").dim()
             );
-            (None, None)
+            let default_url = "http://localhost:11434";
+            let url: String = Input::new()
+                .with_prompt("Ollama base URL")
+                .default(default_url.into())
+                .interact_text()
+                .unwrap_or_else(|_| default_url.into());
+            let base_url = if url.trim().is_empty() { None } else { Some(url) };
+            (None, base_url, None)
         }
     };
 
@@ -240,6 +262,7 @@ pub fn run_init_wizard(output_path: Option<&Path>) -> anyhow::Result<Option<Wiza
     print_wizard_summary(
         &provider,
         &api_key,
+        &base_url,
         &vertex_project,
         max_prs,
         max_repos,
@@ -259,6 +282,7 @@ pub fn run_init_wizard(output_path: Option<&Path>) -> anyhow::Result<Option<Wiza
     Ok(Some(WizardResult {
         provider,
         api_key,
+        base_url,
         vertex_project,
         github_token,
         max_prs_per_day: max_prs,
@@ -270,6 +294,7 @@ pub fn run_init_wizard(output_path: Option<&Path>) -> anyhow::Result<Option<Wiza
 fn print_wizard_summary(
     provider: &LlmChoice,
     api_key: &Option<String>,
+    base_url: &Option<String>,
     vertex_project: &Option<String>,
     max_prs: u32,
     max_repos: u32,
@@ -290,6 +315,13 @@ fn print_wizard_summary(
     if let Some(k) = api_key {
         let masked = mask_secret(k);
         println!("  {:<20} {}", style("API Key:").dim(), style(masked).cyan());
+    }
+    if let Some(u) = base_url {
+        println!(
+            "  {:<20} {}",
+            style("Base URL:").dim(),
+            style(u).cyan()
+        );
     }
     if let Some(p) = vertex_project {
         println!(
@@ -378,6 +410,11 @@ fn apply_wizard_to_yaml(yaml: &str, result: &WizardResult) -> String {
         else if trimmed.starts_with("api_key:") {
             let val = result.api_key.as_deref().unwrap_or("");
             *line = format!("  api_key: \"{}\"", val);
+        }
+        // Base URL
+        else if trimmed.starts_with("base_url:") {
+            let val = result.base_url.as_deref().unwrap_or("");
+            *line = format!("  base_url: \"{}\"", val);
         }
         // Vertex project
         else if trimmed.starts_with("vertex_project:") {
@@ -537,6 +574,7 @@ mod tests {
         let result = WizardResult {
             provider: LlmChoice::OpenAi,
             api_key: Some("sk-test123".into()),
+            base_url: None,
             vertex_project: None,
             github_token: None,
             max_prs_per_day: 10,

--- a/crates/contribai-rs/src/cli/wizard.rs
+++ b/crates/contribai-rs/src/cli/wizard.rs
@@ -394,6 +394,8 @@ pub fn write_wizard_config(result: &WizardResult) -> anyhow::Result<()> {
 fn apply_wizard_to_yaml(yaml: &str, result: &WizardResult) -> String {
     let mut lines: Vec<String> = yaml.lines().map(String::from).collect();
 
+    let mut has_base_url = false;
+
     for line in &mut lines {
         let trimmed = line.trim_start().to_string();
 
@@ -413,6 +415,7 @@ fn apply_wizard_to_yaml(yaml: &str, result: &WizardResult) -> String {
         }
         // Base URL
         else if trimmed.starts_with("base_url:") {
+            has_base_url = true;
             let val = result.base_url.as_deref().unwrap_or("");
             *line = format!("  base_url: \"{}\"", val);
         }
@@ -436,6 +439,15 @@ fn apply_wizard_to_yaml(yaml: &str, result: &WizardResult) -> String {
         }
     }
 
+    // If base_url: is missing from the file (legacy config), insert it after api_key:
+    if !has_base_url {
+        let val = result.base_url.as_deref().unwrap_or("");
+        let insert = format!("  base_url: \"{}\"", val);
+        if let Some(i) = lines.iter().position(|l| l.trim_start().starts_with("api_key:")) {
+            lines.insert(i + 1, insert);
+        }
+    }
+
     lines.join("\n") + "\n"
 }
 
@@ -455,6 +467,7 @@ llm:
   provider: "gemini"
   model: "gemini-3-flash-preview"
   api_key: ""
+  base_url: ""
   temperature: 0.3
   max_tokens: 8192
   vertex_project: ""
@@ -570,11 +583,11 @@ mod tests {
 
     #[test]
     fn test_apply_wizard_to_yaml() {
-        let yaml = "llm:\n  provider: \"gemini\"\n  model: \"old-model\"\n  api_key: \"\"\n  vertex_project: \"\"\n";
+        let yaml = "llm:\n  provider: \"gemini\"\n  model: \"old-model\"\n  api_key: \"\"\n  base_url: \"\"\n  vertex_project: \"\"\n";
         let result = WizardResult {
             provider: LlmChoice::OpenAi,
             api_key: Some("sk-test123".into()),
-            base_url: None,
+            base_url: Some("https://api.openai.com/v1".into()),
             vertex_project: None,
             github_token: None,
             max_prs_per_day: 10,
@@ -585,6 +598,30 @@ mod tests {
         assert!(updated.contains("openai"));
         assert!(updated.contains("gpt-4o"));
         assert!(updated.contains("sk-test123"));
+        assert!(updated.contains("base_url: \"https://api.openai.com/v1\""));
+    }
+
+    /// Verifies base_url is inserted when missing from legacy config.yaml
+    #[test]
+    fn test_apply_wizard_to_yaml_inserts_base_url_when_missing() {
+        // Legacy config without base_url: key
+        let yaml = "llm:\n  provider: \"anthropic\"\n  model: \"claude-3-5-sonnet-20241022\"\n  api_key: \"sk-old\"\n  temperature: 0.3\n  vertex_project: \"\"\n";
+        let result = WizardResult {
+            provider: LlmChoice::Anthropic,
+            api_key: Some("sk-new".into()),
+            base_url: Some("https://api.anthropic.com/v1".into()),
+            vertex_project: None,
+            github_token: None,
+            max_prs_per_day: 15,
+            max_repos_per_run: 20,
+            output_path: std::path::PathBuf::from("test.yaml"),
+        };
+        let updated = apply_wizard_to_yaml(yaml, &result);
+        assert!(updated.contains("base_url: \"https://api.anthropic.com/v1\""));
+        // base_url inserted after api_key
+        let api_key_pos = updated.find("api_key: \"sk-new\"").unwrap();
+        let base_url_pos = updated.find("base_url: \"https://api.anthropic.com/v1\"").unwrap();
+        assert!(base_url_pos > api_key_pos);
     }
 
     #[test]

--- a/crates/contribai-rs/src/llm/provider.rs
+++ b/crates/contribai-rs/src/llm/provider.rs
@@ -693,6 +693,7 @@ impl LlmProvider for OpenAIProvider {
 pub struct AnthropicProvider {
     client: Client,
     api_key: String,
+    base_url: String,
     model: String,
     temperature: f64,
     max_tokens: u32,
@@ -707,11 +708,17 @@ impl AnthropicProvider {
                 .map_err(|_| ContribError::Llm("ANTHROPIC_API_KEY not set".into()))?
         };
 
-        info!(model = %config.model, "Anthropic provider");
+        let base_url = config
+            .base_url
+            .clone()
+            .unwrap_or_else(|| "https://api.anthropic.com/v1".to_string());
+
+        info!(model = %config.model, base_url = %base_url, "Anthropic provider");
 
         Ok(Self {
             client: Client::new(),
             api_key,
+            base_url,
             model: config.model.clone(),
             temperature: config.temperature,
             max_tokens: config.max_tokens,
@@ -761,7 +768,7 @@ impl LlmProvider for AnthropicProvider {
 
         let response = self
             .client
-            .post("https://api.anthropic.com/v1/messages")
+            .post(self.base_url.to_string() + "/messages")
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", "2023-06-01")
             .header("content-type", "application/json")
@@ -1007,6 +1014,54 @@ mod tests {
         };
         let result = create_llm_provider(&config);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_create_anthropic_with_key() {
+        let config = LlmConfig {
+            provider: "anthropic".into(),
+            api_key: "sk-ant-test123".into(),
+            model: "claude-sonnet-4-20250514".into(),
+            temperature: 0.3,
+            max_tokens: 4096,
+            base_url: None,
+            vertex_project: String::new(),
+            vertex_location: "global".into(),
+        };
+        let result = create_llm_provider(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_anthropic_default_base_url() {
+        let config = LlmConfig {
+            provider: "anthropic".into(),
+            api_key: "sk-ant-test123".into(),
+            model: "claude-sonnet-4-20250514".into(),
+            temperature: 0.3,
+            max_tokens: 4096,
+            base_url: None,
+            vertex_project: String::new(),
+            vertex_location: "global".into(),
+        };
+        let p = AnthropicProvider::new(&config).unwrap();
+        assert_eq!(p.base_url, "https://api.anthropic.com/v1");
+    }
+
+    #[test]
+    fn test_anthropic_custom_base_url() {
+        let config = LlmConfig {
+            provider: "anthropic".into(),
+            api_key: "sk-ant-test123".into(),
+            model: "claude-sonnet-4-20250514".into(),
+            temperature: 0.3,
+            max_tokens: 4096,
+            base_url: Some("https://my-proxy.example.com/v1".into()),
+            vertex_project: String::new(),
+            vertex_location: "global".into(),
+        };
+        let p = AnthropicProvider::new(&config).unwrap();
+        assert_eq!(p.base_url, "https://my-proxy.example.com/v1");
     }
 
     #[test]

--- a/python/llm/provider.py
+++ b/python/llm/provider.py
@@ -232,7 +232,10 @@ class AnthropicProvider(LLMProvider):
         try:
             from anthropic import AsyncAnthropic
 
-            self._client = AsyncAnthropic(api_key=config.api_key)
+            kwargs = {"api_key": config.api_key}
+            if config.base_url:
+                kwargs["base_url"] = config.base_url
+            self._client = AsyncAnthropic(**kwargs)
         except ImportError as e:
             raise LLMError("anthropic package not installed") from e
 

--- a/python/tests/unit/test_llm_provider.py
+++ b/python/tests/unit/test_llm_provider.py
@@ -94,3 +94,24 @@ class TestOllamaProvider:
         config = LLMConfig(provider="ollama", model="test-model")
         provider = OllamaProvider(config)
         await provider.close()  # Should not raise
+
+
+class TestAnthropicProvider:
+    def test_base_url_passed_to_client(self):
+        with patch("contribai.llm.provider.anthropic.AsyncAnthropic") as mock_cls:
+            config = LLMConfig(
+                provider="anthropic",
+                api_key="test-key",
+                base_url="https://my-proxy.example.com/v1",
+            )
+            AnthropicProvider(config)
+            mock_cls.assert_called_once_with(
+                api_key="test-key",
+                base_url="https://my-proxy.example.com/v1",
+            )
+
+    def test_base_url_omitted_when_not_set(self):
+        with patch("contribai.llm.provider.anthropic.AsyncAnthropic") as mock_cls:
+            config = LLMConfig(provider="anthropic", api_key="test-key")
+            AnthropicProvider(config)
+            mock_cls.assert_called_once_with(api_key="test-key")


### PR DESCRIPTION
Well I do not have the official open ai or claude plan, so I decide to use my own provider plan. Works so far :) !

## Summary
- Fix `base_url` not being saved in `config.yaml` when running `contribai init` or switching LLM providers in `contribai login`
- The wizard now inserts `base_url` when missing from legacy config files
- `login` flow now prompts for and saves `base_url` for OpenAI, Anthropic, and Ollama providers
- Register `llm.base_url` in config editor so `contribai config set llm.base_url` works

## Test plan
- [x] Unit tests pass (371 tests, including new insertion test)
- [x] `test_apply_wizard_to_yaml_inserts_base_url_when_missing` verifies base_url is inserted into YAML that lacks the key