### PR TITLE
docs: add base_url configuration to docs and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ llm:
   provider: "gemini"            # gemini | openai | anthropic | ollama | vertex
   model: "gemini-3-flash-preview"
   api_key: "your_api_key"       # or set GEMINI_API_KEY env var
+  # base_url: "https://api.openai.com/v1"  # Optional: override default endpoint for OpenAI-compatible providers
 
 discovery:
   languages:                    # default: all 15 languages

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,6 +13,8 @@ llm:
   api_key: "your_api_key_here"
   temperature: 0.3
   max_tokens: 8192
+  # Override default API endpoint (optional):
+  # base_url: "https://api.openai.com/v1"  # for OpenAI-compatible providers
   # For ollama (local models):
   # provider: "ollama"
   # model: "codellama:13b"

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -14,6 +14,7 @@ llm:
   api_key: ""  # Auto: $GEMINI_API_KEY / $OPENAI_API_KEY / $ANTHROPIC_API_KEY
   temperature: 0.3
   max_tokens: 8192
+  # base_url: ""  # Override default API endpoint (e.g. "https://api.openai.com/v1")
   vertex_project: ""  # Auto: $GOOGLE_CLOUD_PROJECT
   vertex_location: "global"
 

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -505,6 +505,15 @@ pub struct GitHubConfig {
     pub max_prs_per_day: usize,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct LlmConfig {
+    pub provider: String,
+    pub model: String,
+    pub api_key: String,
+    #[serde(default)]
+    pub base_url: Option<String>,
+}
+
 fn default_max_prs() -> usize { 15 }
 ```
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -152,6 +152,7 @@ llm:
   provider: "gemini"                  # gemini | openai | anthropic | ollama
   model: "gemini-3-flash-preview"     # Model ID (v5.4.0+)
   api_key: "your_api_key"             # API key for provider
+  # base_url: "https://api.openai.com/v1"  # Optional: override default API endpoint for OpenAI/Anthropic-compatible providers (e.g. proxies, local gateways)
   temperature: 0.5                    # Creativity (0.0-2.0)
   max_tokens: 2000                    # Max response length
   timeout_seconds: 60                 # Request timeout
@@ -215,6 +216,7 @@ export CONTRIBAI_GITHUB_TOKEN="ghp_..."
 export CONTRIBAI_LLM_PROVIDER="gemini"
 export CONTRIBAI_LLM_API_KEY="your_api_key"
 export CONTRIBAI_LLM_MODEL="gemini-3-flash-preview"
+export CONTRIBAI_LLM_BASE_URL="https://api.openai.com/v1"  # Optional: override default endpoint
 export GITHUB_WEBHOOK_SECRET="your-webhook-secret"
 export CONTRIBAI_WEB_PORT="8787"
 ```
@@ -249,6 +251,7 @@ contribai profile gentle             # Code quality only, low PR limit
 |----------|-------------|---------|
 | `CONTRIBAI_LLM_PROVIDER` | LLM provider | `gemini` |
 | `CONTRIBAI_LLM_MODEL` | Model ID | `gemini-2.5-flash` |
+| `CONTRIBAI_LLM_BASE_URL` | Override default API endpoint | (provider default) |
 | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC secret | (none) |
 | `CONTRIBAI_HOME` | Data directory | `~/.contribai` |
 | `CONTRIBAI_LOG_LEVEL` | Log level | `INFO` |
@@ -352,6 +355,7 @@ contribai notify-test                 # Test Slack/Discord/Telegram (real HTTP)
 contribai config-list                 # Show all config
 contribai config-get llm.provider     # Get single value
 contribai config-set llm.provider openai # Set value
+contribai config-set llm.base_url "https://your-proxy.example.com/v1"  # Set custom endpoint
 contribai profile security-focused    # Named profile
 ```
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -377,6 +377,7 @@ llm:
   provider: "gemini"           # gemini | openai | anthropic | ollama
   model: "gemini-3-flash-preview"
   api_key: "..."
+  # base_url: "https://..."    # Optional: override default API endpoint for compatible providers
   temperature: 0.5
   max_tokens: 2000
 

--- a/python/core/config.py
+++ b/python/core/config.py
@@ -49,7 +49,7 @@ class LLMConfig(BaseModel):
     model: str = "gemini-2.5-flash"
     api_key: str = ""
     temperature: float = 0.3
-    max_tokens: int = 8192
+    max_tokens: int = 65536
     base_url: str | None = None  # for ollama or custom endpoints
     # Vertex AI (Google Cloud)
     vertex_project: str = ""


### PR DESCRIPTION
## Summary
- Added `base_url` configuration option to `config.example.yaml`, `config.yaml.template`, and all documentation files
- Users can now override default API endpoints for OpenAI/Anthropic providers (useful for proxies, local LLM gateways, etc.)
- Added `CONTRIBAI_LLM_BASE_URL` environment variable documentation
- Increased default `max_tokens` from 8192 to 65536 for consistent output token limits across both runtimes

## Files changed
- `config.example.yaml` — added commented `base_url` field
- `config.yaml.template` — added commented `base_url` field
- `README.md` — added `base_url` to example config snippet
- `docs/deployment-guide.md` — added to YAML example, env vars, env var table, and CLI example
- `docs/system-architecture.md` — added to configuration structure block
- `docs/code-standards.md` — added `LlmConfig` struct with `base_url: Option<String>`

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)