### PR TITLE
Security: Potential Path Traversal in Log File Path Resolution

### DIFF
--- a/crates/contribai-rs/src/core/logging.rs
+++ b/crates/contribai-rs/src/core/logging.rs
@@ -27,9 +27,26 @@ pub fn init_json_logging(level: &str, log_file: Option<&Path>) {
     std::env::set_var("RUST_LOG", level);
 
     if let Some(path) = log_file {
-        if let Some(parent) = path.parent() {
+        let log_dir = dirs::home_dir()
+            .map(|mut d| {
+                d.push(".contribai");
+                d.push("logs");
+                d
+            })
+            .unwrap_or_else(|| Path::new(".").to_path_buf());
+
+        let canonical_path = match std::fs::canonicalize(path) {
+            Ok(p) => p,
+            Err(_) => log_dir.join(path.file_name().unwrap_or_default()),
+        };
+
+        if !canonical_path.starts_with(&log_dir) {
+            return;
+        }
+
+        if let Some(parent) = canonical_path.parent() {
             let _ = create_dir_all(parent);
         }
-        tracing::info!(file = %path.display(), "JSON logging initialized");
+        tracing::info!(file = %canonical_path.display(), "JSON logging initialized");
     }
 }


### PR DESCRIPTION
## Summary

Security: Potential Path Traversal in Log File Path Resolution

## Problem

**Severity**: `Medium` | **File**: `crates/contribai-rs/src/core/logging.rs:L36`

In `crates/contribai-rs/src/core/logging.rs`, the `init_json_logging` function accepts a `log_file: Option<&Path>` parameter and passes it directly to `tracing::info!(file = %path.display(), ...)`. If an attacker can control the config's log file path (e.g., via a malicious config.yaml with `log.file: "../../etc/passwd"`), this could lead to unintended file writes or information disclosure. Additionally, there is no validation that the path is within an allowed directory.

## Solution

Validate and sanitize the log file path: ensure it is absolute, resides within a designated log directory (e.g., ~/.contribai/logs/), and does not contain directory traversal sequences. Use `Path::canonicalize` and `starts_with` checks before using the path.

## Changes

- `crates/contribai-rs/src/core/logging.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*