### PR TITLE
fix: Sprint 22.6 — compile error + clippy 1.95 + failing tests + version sync

### DIFF
--- a/crates/contribai-rs/Cargo.toml
+++ b/crates/contribai-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contribai"
-version = "6.0.0"
+version = "6.2.0"
 edition = "2021"
 authors = ["tang-vu <tang.vu@contribai.dev>"]
 description = "AI agent that autonomously contributes to open source projects on GitHub"

--- a/crates/contribai-rs/src/analysis/ast_intel.rs
+++ b/crates/contribai-rs/src/analysis/ast_intel.rs
@@ -357,6 +357,7 @@ impl AstIntel {
     }
 
     /// Walk AST nodes to extract import targets with source paths.
+    #[allow(clippy::collapsible_match)]
     fn walk_import_nodes(
         node: tree_sitter::Node,
         source: &str,
@@ -742,8 +743,13 @@ impl AstIntel {
                     continue;
                 }
 
-                // Find file B that file A imports from
-                for file_b_path in parsed_files.keys() {
+                // Find file B that file A imports from.
+                // Look in file_imports (not parsed_files) so we can follow chains
+                // even when file B's symbols haven't been parsed.
+                for file_b_path in file_imports.keys() {
+                    if file_b_path == file_a {
+                        continue;
+                    }
                     if !paths_match(&target_a.source_path, file_b_path) {
                         continue;
                     }

--- a/crates/contribai-rs/src/analysis/repo_intel.rs
+++ b/crates/contribai-rs/src/analysis/repo_intel.rs
@@ -278,7 +278,7 @@ impl<'a> RepoIntelligence<'a> {
             }
         }
 
-        actionable.sort_by(|a, b| b.score.cmp(&a.score));
+        actionable.sort_by_key(|b| std::cmp::Reverse(b.score));
         Ok(actionable.into_iter().take(10).collect())
     }
 }

--- a/crates/contribai-rs/src/cli/tui.rs
+++ b/crates/contribai-rs/src/cli/tui.rs
@@ -637,7 +637,7 @@ fn render_repos(f: &mut Frame, area: Rect, app: &App) {
                 .iter()
                 .filter(|p| &p.repo == r && p.status == "merged")
                 .count();
-            let rate = if total > 0 { merged * 100 / total } else { 0 };
+            let rate = (merged * 100).checked_div(total).unwrap_or(0);
             ListItem::new(Line::from(vec![
                 Span::styled(
                     format!("  {:<35}", r.chars().take(34).collect::<String>()),

--- a/crates/contribai-rs/src/generator/json_parser.rs
+++ b/crates/contribai-rs/src/generator/json_parser.rs
@@ -339,7 +339,7 @@ mod tests {
         // Wrong type
         let invalid2 = r#"{"changes": "not an array"}"#;
         let parsed: serde_json::Value = serde_json::from_str(invalid2).unwrap();
-        assert!(!validate_change_schema(&invalid2));
+        assert!(!validate_change_schema(&parsed));
     }
 }
 

--- a/crates/contribai-rs/src/github/guidelines.rs
+++ b/crates/contribai-rs/src/github/guidelines.rs
@@ -350,6 +350,10 @@ pub fn detects_ai_ban(guidelines: &str) -> bool {
         r"no\s+(machine|automated|scripted|generated)\s+contributions?",
         r"(contributions?|pr[s]?)\s+must\s+be\s+(written|made|done)\s+by\s+humans?",
         r"no\s+(llm|gpt|claude|copilot|gemini)\s+(contrib|pr|generated|code)",
+        // Catches "GPT generated code", "LLM-written code", etc. without requiring "no" prefix
+        r"\b(llm|gpt|claude|copilot|gemini)[-\s]+(generated|written|created)\s+(code|contributions?|pr[s]?)",
+        // Catches "only accept manual contributions" / "only allow human PRs"
+        r"only\s+(accept|allow|welcome|approve)\s+(manual|human|hand[-\s]?written)",
     ];
 
     for pattern in &patterns {
@@ -367,6 +371,7 @@ pub fn detects_ai_ban(guidelines: &str) -> bool {
 
 /// Check AI_POLICY.md content for ban keywords.
 fn detect_ai_policy_ban(text: &str) -> bool {
+    let lowered = text.to_lowercase();
     let ban_phrases = [
         "ai contributions are not allowed",
         "automated contributions prohibited",
@@ -375,7 +380,7 @@ fn detect_ai_policy_ban(text: &str) -> bool {
     ];
 
     for phrase in &ban_phrases {
-        if text.contains(phrase) {
+        if lowered.contains(phrase) {
             return true;
         }
     }

--- a/crates/contribai-rs/src/pr/patrol.rs
+++ b/crates/contribai-rs/src/pr/patrol.rs
@@ -144,6 +144,7 @@ impl<'a> PrPatrol<'a> {
     }
 
     /// Check a single PR for feedback.
+    #[allow(clippy::collapsible_match)]
     async fn check_single_pr(
         &self,
         owner: &str,
@@ -902,7 +903,7 @@ mod tests {
 
     #[test]
     fn test_parse_classifications() {
-        let feedback = vec![FeedbackItem {
+        let _feedback = vec![FeedbackItem {
             comment_id: 1,
             author: "maintainer".into(),
             body: "Please fix this".into(),

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-﻿$Version = "v5.2.0"
+﻿$Version = "v6.2.0"
 $Repo = "tang-vu/ContribAI"
 $Binary = "contribai-windows-x86_64.exe"
 $InstallDir = "$env:USERPROFILE\.contribai\bin"

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 ﻿#!/bin/bash
 set -e
 
-VERSION="v5.2.0"
+VERSION="v6.2.0"
 REPO="tang-vu/ContribAI"
 INSTALL_DIR="/usr/local/bin"
 


### PR DESCRIPTION
## Summary

Comprehensive cleanup that bundles the contributions from #27 with fixes for additional issues blocking CI on `main`. Closes #27 (credit retained via `Co-authored-by`).

## Issues fixed

### 1. Compile error (was blocking ALL PR CI)
- `crates/contribai-rs/src/generator/json_parser.rs:342` — `validate_change_schema(&invalid2)` was passing `&&str` to a function expecting `&serde_json::Value`. **E0308**, originally caught by @Rudasingwa-kevin in #27.

### 2. Clippy 1.95 lints (CI uses `-D warnings`)
- `repo_intel.rs:281` — replaced `sort_by(|a,b| b.score.cmp(&a.score))` with `sort_by_key(|b| std::cmp::Reverse(b.score))`
- `ast_intel.rs::walk_import_nodes` & `patrol.rs::check_single_pr` — added `#[allow(clippy::collapsible_match)]`. Refactoring to match-arm guards would change fallthrough semantics for the JS/TS, Rust, Go, Java arms (current code is `match Lang { Lang::X => if kind == "..." {...} }`; converting the `if` to a guard would let unmatched kinds fall through to subsequent arms instead of doing nothing).

### 3. Failing tests (4)
- `analysis::ast_intel::tests::test_multihop_2hop_resolution` — 2-hop import resolution looked up file B in `parsed_files.keys()`. Fixed to iterate `file_imports.keys()` so chains can follow files whose symbols haven't been parsed yet (which is the whole point of multi-hop).
- `github::guidelines::tests::test_detect_ai_policy_ban` — function called `text.contains(\"ai contributions are not allowed\")` but tests passed mixed-case input. Fixed to lowercase input inside the function.
- `github::guidelines::tests::test_detects_ai_ban_llm` — added pattern `\b(llm|gpt|...)[-\s]+(generated|written|created)\s+(code|...)`. Old pattern required `no\s+(llm|gpt|...)\s+(generated|...)` which fails for \"No LLM **or GPT** generated code\".
- `github::guidelines::tests::test_detects_ai_ban_manual_only` — added pattern `only\s+(accept|allow|welcome|approve)\s+(manual|human|...)`. Old pattern required `manual\s+contributions?\s+only` which fails for \"only accept manual contributions\".

### 4. Version inconsistency (from #27)
- `Cargo.toml` 6.0.0 → 6.2.0
- `install.sh` v5.2.0 → v6.2.0
- `install.ps1` v5.2.0 → v6.2.0
- README badge already shows v6.2.0

## Local verification
- `cargo test --lib` → **464 passed, 0 failed** (was 460 passed, 4 failed)
- `cargo clippy --lib -- -D warnings` → clean (local toolchain 1.92; 1.95 lints addressed via inspection of CI logs)
- `cargo fmt --check` → clean

## Test plan
- [x] All 4 previously failing tests pass locally
- [x] Full lib test suite passes (464 tests)
- [x] No regressions in negative-case tests (welcome/normal-contributing/conventional-commits still don't trigger ai_ban)
- [ ] CI green on rust 1.95.0