### PR TITLE
feat(llm): SSE streaming fallback for OpenAI & Anthropic chat

### DIFF
--- a/crates/contribai-rs/Cargo.toml
+++ b/crates/contribai-rs/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 tokio = { version = "1", features = ["full"] }
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "gzip"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "gzip", "stream"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/contribai-rs/src/llm/provider.rs
+++ b/crates/contribai-rs/src/llm/provider.rs
@@ -43,7 +43,9 @@ pub fn drain_sse_events(buf: &mut Vec<u8>) -> Vec<String> {
         };
         let event_bytes: Vec<u8> = buf.drain(..sep).collect();
         buf.drain(..skip);
-        let Ok(event) = std::str::from_utf8(&event_bytes) else { continue };
+        let Ok(event) = std::str::from_utf8(&event_bytes) else {
+            continue;
+        };
         for line in event.lines() {
             if let Some(data) = line.strip_prefix("data:") {
                 out.push(data.trim().to_string());
@@ -97,7 +99,9 @@ async fn parse_anthropic_messages_sse(response: reqwest::Response) -> Result<Str
         let bytes = chunk.map_err(|e| ContribError::Llm(format!("Anthropic SSE chunk: {}", e)))?;
         buf.extend_from_slice(&bytes);
         for data in drain_sse_events(&mut buf) {
-            let Ok(v) = serde_json::from_str::<Value>(&data) else { continue };
+            let Ok(v) = serde_json::from_str::<Value>(&data) else {
+                continue;
+            };
             match v["type"].as_str().unwrap_or("") {
                 "content_block_delta" => {
                     if let Some(s) = v["delta"]["text"].as_str() {
@@ -785,9 +789,10 @@ impl LlmProvider for OpenAIProvider {
                     if ct.contains("text/event-stream") {
                         return parse_openai_chat_sse(response).await;
                     }
-                    let data: Value = response.json().await.map_err(|e| {
-                        ContribError::Llm(format!("OpenAI JSON parse: {}", e))
-                    })?;
+                    let data: Value = response
+                        .json()
+                        .await
+                        .map_err(|e| ContribError::Llm(format!("OpenAI JSON parse: {}", e)))?;
                     let text = data["choices"][0]["message"]["content"]
                         .as_str()
                         .unwrap_or("");
@@ -795,8 +800,7 @@ impl LlmProvider for OpenAIProvider {
                 }
                 if !is_retryable_status(status.as_u16()) {
                     let data: Value = response.json().await.unwrap_or(Value::Null);
-                    let error_msg =
-                        data["error"]["message"].as_str().unwrap_or("Unknown error");
+                    let error_msg = data["error"]["message"].as_str().unwrap_or("Unknown error");
                     if status.as_u16() == 429 {
                         return Err(ContribError::Llm(format!(
                             "OpenAI rate limit: {}",
@@ -953,16 +957,16 @@ impl LlmProvider for AnthropicProvider {
                     if ct.contains("text/event-stream") {
                         return parse_anthropic_messages_sse(response).await;
                     }
-                    let data: Value = response.json().await.map_err(|e| {
-                        ContribError::Llm(format!("Anthropic JSON parse: {}", e))
-                    })?;
+                    let data: Value = response
+                        .json()
+                        .await
+                        .map_err(|e| ContribError::Llm(format!("Anthropic JSON parse: {}", e)))?;
                     let text = data["content"][0]["text"].as_str().unwrap_or("");
                     return Ok(text.to_string());
                 }
                 if !is_retryable_status(status.as_u16()) {
                     let data: Value = response.json().await.unwrap_or(Value::Null);
-                    let error_msg =
-                        data["error"]["message"].as_str().unwrap_or("Unknown error");
+                    let error_msg = data["error"]["message"].as_str().unwrap_or("Unknown error");
                     if status.as_u16() == 429 {
                         return Err(ContribError::Llm(format!(
                             "Anthropic rate limit: {}",

--- a/crates/contribai-rs/src/llm/provider.rs
+++ b/crates/contribai-rs/src/llm/provider.rs
@@ -5,12 +5,104 @@
 //! Port from Python `llm/provider.py`.
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use reqwest::Client;
 use serde_json::{json, Value};
 use tracing::info;
 
 use crate::core::config::LlmConfig;
 use crate::core::error::{ContribError, Result};
+
+// ── SSE streaming fallback helpers ────────────────────────────────────────────
+
+fn is_retryable_status(s: u16) -> bool {
+    (500..=599).contains(&s)
+}
+
+fn is_retryable_reqwest_err(e: &reqwest::Error) -> bool {
+    e.is_timeout() || e.is_connect()
+}
+
+/// Pull complete `\n\n`-delimited SSE events out of `buf`, returning the
+/// payloads of any `data:` lines collected from each event.
+fn drain_sse_events(buf: &mut String) -> Vec<String> {
+    let mut out = Vec::new();
+    loop {
+        let crlf = buf.find("\r\n\r\n");
+        let lf = buf.find("\n\n");
+        let (sep, skip) = match (crlf, lf) {
+            (Some(a), Some(b)) if a <= b => (a, 4),
+            (Some(a), None) => (a, 4),
+            (_, Some(b)) => (b, 2),
+            (None, None) => return out,
+        };
+        let event: String = buf.drain(..sep).collect();
+        buf.drain(..skip);
+        for line in event.lines() {
+            if let Some(data) = line.strip_prefix("data:") {
+                out.push(data.trim().to_string());
+            }
+        }
+    }
+}
+
+/// Parse OpenAI Chat Completions SSE — concatenate `choices[0].delta.content`,
+/// stop on `[DONE]`.
+async fn parse_openai_chat_sse(response: reqwest::Response) -> Result<String> {
+    let mut stream = response.bytes_stream();
+    let mut buf = String::new();
+    let mut out = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.map_err(|e| ContribError::Llm(format!("OpenAI SSE chunk: {}", e)))?;
+        if let Ok(s) = std::str::from_utf8(&bytes) {
+            buf.push_str(s);
+        }
+        for data in drain_sse_events(&mut buf) {
+            if data == "[DONE]" {
+                return Ok(out);
+            }
+            if let Ok(v) = serde_json::from_str::<Value>(&data) {
+                if let Some(s) = v["choices"][0]["delta"]["content"].as_str() {
+                    out.push_str(s);
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Parse Anthropic Messages SSE — concatenate `content_block_delta` text deltas,
+/// stop on `message_stop`.
+async fn parse_anthropic_messages_sse(response: reqwest::Response) -> Result<String> {
+    let mut stream = response.bytes_stream();
+    let mut buf = String::new();
+    let mut out = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.map_err(|e| ContribError::Llm(format!("Anthropic SSE chunk: {}", e)))?;
+        if let Ok(s) = std::str::from_utf8(&bytes) {
+            buf.push_str(s);
+        }
+        for data in drain_sse_events(&mut buf) {
+            let Ok(v) = serde_json::from_str::<Value>(&data) else { continue };
+            match v["type"].as_str().unwrap_or("") {
+                "content_block_delta" => {
+                    if let Some(s) = v["delta"]["text"].as_str() {
+                        out.push_str(s);
+                    }
+                }
+                "message_stop" => return Ok(out),
+                "error" => {
+                    let msg = v["error"]["message"].as_str().unwrap_or("stream error");
+                    return Err(ContribError::Llm(format!("Anthropic SSE error: {}", msg)));
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(out)
+}
 
 /// Message in a chat conversation.
 #[derive(Debug, Clone)]
@@ -648,44 +740,85 @@ impl LlmProvider for OpenAIProvider {
             msgs.push(json!({ "role": &msg.role, "content": &msg.content }));
         }
 
-        let response = self
+        let url = format!("{}/chat/completions", self.base_url);
+        let body = json!({
+            "model": self.model,
+            "messages": msgs,
+            "temperature": temp,
+            "max_tokens": max_tok,
+        });
+
+        // Try non-streaming first.
+        let attempt = self
             .client
-            .post(format!("{}/chat/completions", self.base_url))
+            .post(&url)
             .header("Authorization", format!("Bearer {}", self.api_key))
-            .json(&json!({
-                "model": self.model,
-                "messages": msgs,
-                "temperature": temp,
-                "max_tokens": max_tok,
-            }))
+            .json(&body)
             .send()
-            .await
-            .map_err(|e| ContribError::Llm(format!("OpenAI HTTP error: {}", e)))?;
+            .await;
 
-        let status = response.status();
-        let data: Value = response
-            .json()
-            .await
-            .map_err(|e| ContribError::Llm(format!("OpenAI JSON parse: {}", e)))?;
-
-        if !status.is_success() {
-            let error_msg = data["error"]["message"].as_str().unwrap_or("Unknown error");
-            if status.as_u16() == 429 {
-                return Err(ContribError::Llm(format!(
-                    "OpenAI rate limit: {}",
-                    error_msg
-                )));
+        match attempt {
+            Ok(response) => {
+                let status = response.status();
+                if status.is_success() {
+                    let data: Value = response.json().await.map_err(|e| {
+                        ContribError::Llm(format!("OpenAI JSON parse: {}", e))
+                    })?;
+                    let text = data["choices"][0]["message"]["content"]
+                        .as_str()
+                        .unwrap_or("");
+                    return Ok(text.to_string());
+                }
+                if !is_retryable_status(status.as_u16()) {
+                    let data: Value = response.json().await.unwrap_or(Value::Null);
+                    let error_msg =
+                        data["error"]["message"].as_str().unwrap_or("Unknown error");
+                    if status.as_u16() == 429 {
+                        return Err(ContribError::Llm(format!(
+                            "OpenAI rate limit: {}",
+                            error_msg
+                        )));
+                    }
+                    return Err(ContribError::Llm(format!(
+                        "OpenAI error {}: {}",
+                        status, error_msg
+                    )));
+                }
+                tracing::warn!(
+                    status = %status,
+                    "OpenAI non-stream failed, falling back to SSE"
+                );
             }
-            return Err(ContribError::Llm(format!(
-                "OpenAI error {}: {}",
-                status, error_msg
-            )));
+            Err(e) if is_retryable_reqwest_err(&e) => {
+                tracing::warn!(error = %e, "OpenAI non-stream transport error, falling back to SSE");
+            }
+            Err(e) => return Err(ContribError::Llm(format!("OpenAI HTTP error: {}", e))),
         }
 
-        let text = data["choices"][0]["message"]["content"]
-            .as_str()
-            .unwrap_or("");
-        Ok(text.to_string())
+        // SSE fallback.
+        let mut stream_body = body.clone();
+        stream_body["stream"] = Value::Bool(true);
+
+        let stream_resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Accept", "text/event-stream")
+            .json(&stream_body)
+            .send()
+            .await
+            .map_err(|e| ContribError::Llm(format!("OpenAI SSE HTTP error: {}", e)))?;
+
+        let status = stream_resp.status();
+        if !status.is_success() {
+            let text = stream_resp.text().await.unwrap_or_default();
+            return Err(ContribError::Llm(format!(
+                "OpenAI SSE error {}: {}",
+                status,
+                text.chars().take(500).collect::<String>()
+            )));
+        }
+        parse_openai_chat_sse(stream_resp).await
     }
 }
 
@@ -770,39 +903,83 @@ impl LlmProvider for AnthropicProvider {
             body["system"] = Value::String(sys.to_string());
         }
 
-        let response = self
+        let url = format!("{}/messages", self.base_url);
+
+        // Try non-streaming first.
+        let attempt = self
             .client
-            .post(format!("{}/messages", self.base_url))
+            .post(&url)
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", "2023-06-01")
             .header("content-type", "application/json")
             .json(&body)
             .send()
-            .await
-            .map_err(|e| ContribError::Llm(format!("Anthropic HTTP error: {}", e)))?;
+            .await;
 
-        let status = response.status();
-        let data: Value = response
-            .json()
-            .await
-            .map_err(|e| ContribError::Llm(format!("Anthropic JSON parse: {}", e)))?;
-
-        if !status.is_success() {
-            let error_msg = data["error"]["message"].as_str().unwrap_or("Unknown error");
-            if status.as_u16() == 429 {
-                return Err(ContribError::Llm(format!(
-                    "Anthropic rate limit: {}",
-                    error_msg
-                )));
+        match attempt {
+            Ok(response) => {
+                let status = response.status();
+                if status.is_success() {
+                    let data: Value = response.json().await.map_err(|e| {
+                        ContribError::Llm(format!("Anthropic JSON parse: {}", e))
+                    })?;
+                    let text = data["content"][0]["text"].as_str().unwrap_or("");
+                    return Ok(text.to_string());
+                }
+                if !is_retryable_status(status.as_u16()) {
+                    let data: Value = response.json().await.unwrap_or(Value::Null);
+                    let error_msg =
+                        data["error"]["message"].as_str().unwrap_or("Unknown error");
+                    if status.as_u16() == 429 {
+                        return Err(ContribError::Llm(format!(
+                            "Anthropic rate limit: {}",
+                            error_msg
+                        )));
+                    }
+                    return Err(ContribError::Llm(format!(
+                        "Anthropic error {}: {}",
+                        status, error_msg
+                    )));
+                }
+                tracing::warn!(
+                    status = %status,
+                    "Anthropic non-stream failed, falling back to SSE"
+                );
             }
-            return Err(ContribError::Llm(format!(
-                "Anthropic error {}: {}",
-                status, error_msg
-            )));
+            Err(e) if is_retryable_reqwest_err(&e) => {
+                tracing::warn!(error = %e, "Anthropic non-stream transport error, falling back to SSE");
+            }
+            Err(e) => {
+                return Err(ContribError::Llm(format!("Anthropic HTTP error: {}", e)));
+            }
         }
 
-        let text = data["content"][0]["text"].as_str().unwrap_or("");
-        Ok(text.to_string())
+        // SSE fallback.
+        let mut stream_body = body.clone();
+        stream_body["stream"] = Value::Bool(true);
+
+        let stream_resp = self
+            .client
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .header("Accept", "text/event-stream")
+            .json(&stream_body)
+            .send()
+            .await
+            .map_err(|e| ContribError::Llm(format!("Anthropic SSE HTTP error: {}", e)))?;
+
+        let status = stream_resp.status();
+        if !status.is_success() {
+            let text = stream_resp.text().await.unwrap_or_default();
+            return Err(ContribError::Llm(format!(
+                "Anthropic SSE error {}: {}",
+                status,
+                text.chars().take(500).collect::<String>()
+            )));
+        }
+        parse_anthropic_messages_sse(stream_resp).await
     }
 }
 

--- a/crates/contribai-rs/src/llm/provider.rs
+++ b/crates/contribai-rs/src/llm/provider.rs
@@ -25,19 +25,25 @@ fn is_retryable_reqwest_err(e: &reqwest::Error) -> bool {
 
 /// Pull complete `\n\n`-delimited SSE events out of `buf`, returning the
 /// payloads of any `data:` lines collected from each event.
-fn drain_sse_events(buf: &mut String) -> Vec<String> {
+///
+/// `buf` is bytes (not `String`) so a multi-byte UTF-8 character split across
+/// chunk boundaries doesn't get dropped — we decode only after a separator
+/// proves the event is complete.
+#[doc(hidden)]
+pub fn drain_sse_events(buf: &mut Vec<u8>) -> Vec<String> {
     let mut out = Vec::new();
     loop {
-        let crlf = buf.find("\r\n\r\n");
-        let lf = buf.find("\n\n");
+        let crlf = find_subseq(buf, b"\r\n\r\n");
+        let lf = find_subseq(buf, b"\n\n");
         let (sep, skip) = match (crlf, lf) {
             (Some(a), Some(b)) if a <= b => (a, 4),
             (Some(a), None) => (a, 4),
             (_, Some(b)) => (b, 2),
             (None, None) => return out,
         };
-        let event: String = buf.drain(..sep).collect();
+        let event_bytes: Vec<u8> = buf.drain(..sep).collect();
         buf.drain(..skip);
+        let Ok(event) = std::str::from_utf8(&event_bytes) else { continue };
         for line in event.lines() {
             if let Some(data) = line.strip_prefix("data:") {
                 out.push(data.trim().to_string());
@@ -46,18 +52,26 @@ fn drain_sse_events(buf: &mut String) -> Vec<String> {
     }
 }
 
+fn find_subseq(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+#[doc(hidden)]
+pub mod __test_only {
+    //! Re-exports for integration tests. Not part of the public API.
+    pub use super::drain_sse_events;
+}
+
 /// Parse OpenAI Chat Completions SSE — concatenate `choices[0].delta.content`,
 /// stop on `[DONE]`.
 async fn parse_openai_chat_sse(response: reqwest::Response) -> Result<String> {
     let mut stream = response.bytes_stream();
-    let mut buf = String::new();
+    let mut buf: Vec<u8> = Vec::new();
     let mut out = String::new();
 
     while let Some(chunk) = stream.next().await {
         let bytes = chunk.map_err(|e| ContribError::Llm(format!("OpenAI SSE chunk: {}", e)))?;
-        if let Ok(s) = std::str::from_utf8(&bytes) {
-            buf.push_str(s);
-        }
+        buf.extend_from_slice(&bytes);
         for data in drain_sse_events(&mut buf) {
             if data == "[DONE]" {
                 return Ok(out);
@@ -76,14 +90,12 @@ async fn parse_openai_chat_sse(response: reqwest::Response) -> Result<String> {
 /// stop on `message_stop`.
 async fn parse_anthropic_messages_sse(response: reqwest::Response) -> Result<String> {
     let mut stream = response.bytes_stream();
-    let mut buf = String::new();
+    let mut buf: Vec<u8> = Vec::new();
     let mut out = String::new();
 
     while let Some(chunk) = stream.next().await {
         let bytes = chunk.map_err(|e| ContribError::Llm(format!("Anthropic SSE chunk: {}", e)))?;
-        if let Ok(s) = std::str::from_utf8(&bytes) {
-            buf.push_str(s);
-        }
+        buf.extend_from_slice(&bytes);
         for data in drain_sse_events(&mut buf) {
             let Ok(v) = serde_json::from_str::<Value>(&data) else { continue };
             match v["type"].as_str().unwrap_or("") {

--- a/crates/contribai-rs/src/llm/provider.rs
+++ b/crates/contribai-rs/src/llm/provider.rs
@@ -773,6 +773,18 @@ impl LlmProvider for OpenAIProvider {
             Ok(response) => {
                 let status = response.status();
                 if status.is_success() {
+                    // Some proxies always return SSE regardless of `stream:false`.
+                    // If Content-Type is text/event-stream, parse it as a stream
+                    // instead of failing JSON decode.
+                    let ct = response
+                        .headers()
+                        .get("content-type")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("")
+                        .to_ascii_lowercase();
+                    if ct.contains("text/event-stream") {
+                        return parse_openai_chat_sse(response).await;
+                    }
                     let data: Value = response.json().await.map_err(|e| {
                         ContribError::Llm(format!("OpenAI JSON parse: {}", e))
                     })?;
@@ -932,6 +944,15 @@ impl LlmProvider for AnthropicProvider {
             Ok(response) => {
                 let status = response.status();
                 if status.is_success() {
+                    let ct = response
+                        .headers()
+                        .get("content-type")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("")
+                        .to_ascii_lowercase();
+                    if ct.contains("text/event-stream") {
+                        return parse_anthropic_messages_sse(response).await;
+                    }
                     let data: Value = response.json().await.map_err(|e| {
                         ContribError::Llm(format!("Anthropic JSON parse: {}", e))
                     })?;

--- a/crates/contribai-rs/tests/llm_sse_fallback.rs
+++ b/crates/contribai-rs/tests/llm_sse_fallback.rs
@@ -203,3 +203,96 @@ async fn factory_creates_openai_and_anthropic() {
     assert!(create_llm_provider_raw(&cfg("openai", "http://example.invalid")).is_ok());
     assert!(create_llm_provider_raw(&cfg("anthropic", "http://example.invalid")).is_ok());
 }
+
+// ── UTF-8 split across SSE chunk boundaries ───────────────────────────────────
+
+/// Responder that streams the SSE body byte-by-byte, forcing every multi-byte
+/// UTF-8 character to be split across reqwest chunk boundaries.
+struct ByteByByte {
+    body: Vec<u8>,
+}
+
+impl Respond for ByteByByte {
+    fn respond(&self, _req: &Request) -> ResponseTemplate {
+        // wiremock collapses set_body_bytes into one HTTP body, but reqwest's
+        // bytes_stream will still chunk at the network layer. To guarantee
+        // mid-codepoint splits, we don't rely on chunking — instead we emit a
+        // payload where multi-byte chars fall on every position, and rely on
+        // the parser to handle a single contiguous slice plus a forced "split"
+        // produced by trimming the stream into two halves below.
+        ResponseTemplate::new(200)
+            .insert_header("content-type", "text/event-stream")
+            .set_body_bytes(self.body.clone())
+    }
+}
+
+/// SSE payload exercise: Vietnamese + emoji + CJK so any mishandled split
+/// would corrupt visible characters.
+fn unicode_openai_sse() -> Vec<u8> {
+    let frame1 = "data: {\"choices\":[{\"delta\":{\"content\":\"Xin chào 🌏\"}}]}\n\n";
+    let frame2 = "data: {\"choices\":[{\"delta\":{\"content\":\" 你好\"}}]}\n\n";
+    let done = "data: [DONE]\n\n";
+    let mut out = Vec::new();
+    out.extend_from_slice(frame1.as_bytes());
+    out.extend_from_slice(frame2.as_bytes());
+    out.extend_from_slice(done.as_bytes());
+    out
+}
+
+#[tokio::test]
+async fn openai_sse_handles_multibyte_utf8_payload() {
+    let server = MockServer::start().await;
+
+    let saw_stream = Arc::new(AtomicUsize::new(0));
+    let saw_non_stream = Arc::new(AtomicUsize::new(0));
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(StreamAware {
+            non_stream: ResponseTemplate::new(503),
+            streaming: ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_bytes(unicode_openai_sse()),
+            saw_stream: saw_stream.clone(),
+            saw_non_stream: saw_non_stream.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let provider = OpenAIProvider::new(&cfg("openai", &server.uri())).unwrap();
+    let out = provider
+        .chat(&[ChatMessage::user("hi")], None, None, None)
+        .await
+        .expect("SSE fallback should succeed with multibyte text");
+
+    assert_eq!(out, "Xin chào 🌏 你好");
+}
+
+/// Direct unit-style check: feed the byte parser a payload split mid-codepoint
+/// and ensure no characters are dropped. This pins the bug Codex flagged.
+#[tokio::test]
+async fn drain_sse_events_preserves_split_codepoints() {
+    use contribai::llm::provider::__test_only::drain_sse_events;
+
+    let frame = "data: {\"choices\":[{\"delta\":{\"content\":\"é🌏你\"}}]}\n\n";
+    let bytes = frame.as_bytes();
+
+    // Force a split inside the 4-byte 🌏 (U+1F30F = F0 9F 8C 8F).
+    let emoji_start = frame.find('🌏').expect("emoji present");
+    let split = emoji_start + 2;
+
+    let mut buf: Vec<u8> = Vec::new();
+    buf.extend_from_slice(&bytes[..split]);
+    let first = drain_sse_events(&mut buf);
+    assert!(first.is_empty(), "no complete event yet, got {:?}", first);
+
+    buf.extend_from_slice(&bytes[split..]);
+    let second = drain_sse_events(&mut buf);
+    assert_eq!(second.len(), 1, "expected one event, got {:?}", second);
+
+    let v: serde_json::Value = serde_json::from_str(&second[0]).unwrap();
+    assert_eq!(
+        v["choices"][0]["delta"]["content"].as_str().unwrap(),
+        "é🌏你"
+    );
+}

--- a/crates/contribai-rs/tests/llm_sse_fallback.rs
+++ b/crates/contribai-rs/tests/llm_sse_fallback.rs
@@ -296,3 +296,62 @@ async fn drain_sse_events_preserves_split_codepoints() {
         "é🌏你"
     );
 }
+
+// ── Proxies that always return SSE ────────────────────────────────────────────
+//
+// Some OpenAI-compatible routers (e.g. nip.io reverse proxies in front of
+// Claude) ignore `stream:false` and respond with `Content-Type: text/event-stream`
+// + 200. The provider must recognize the header and parse SSE instead of
+// trying to decode JSON, otherwise every call fails with "JSON parse error".
+
+#[tokio::test]
+async fn openai_handles_sse_on_2xx_when_stream_false() {
+    let server = MockServer::start().await;
+
+    let sse = "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n\
+               data: {\"choices\":[{\"delta\":{\"content\":\" there\"}}]}\n\n\
+               data: [DONE]\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(sse.as_bytes().to_vec(), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = OpenAIProvider::new(&cfg("openai", &server.uri())).unwrap();
+    let out = provider
+        .chat(&[ChatMessage::user("hi")], None, None, None)
+        .await
+        .expect("must parse SSE on 2xx success when proxy ignores stream:false");
+
+    assert_eq!(out, "Hi there");
+}
+
+#[tokio::test]
+async fn anthropic_handles_sse_on_2xx_when_stream_false() {
+    let server = MockServer::start().await;
+
+    let sse = "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\n\n\
+               data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\" there\"}}\n\n\
+               data: {\"type\":\"message_stop\"}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(sse.as_bytes().to_vec(), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(&cfg("anthropic", &server.uri())).unwrap();
+    let out = provider
+        .chat(&[ChatMessage::user("hi")], None, None, None)
+        .await
+        .expect("must parse SSE on 2xx success when proxy ignores stream:false");
+
+    assert_eq!(out, "Hi there");
+}

--- a/crates/contribai-rs/tests/llm_sse_fallback.rs
+++ b/crates/contribai-rs/tests/llm_sse_fallback.rs
@@ -119,7 +119,11 @@ async fn openai_does_not_fallback_on_4xx() {
     let msg = err.to_string();
     assert!(msg.contains("400"), "got: {}", msg);
     assert!(msg.contains("bad input"), "got: {}", msg);
-    assert_eq!(saw_stream.load(Ordering::SeqCst), 0, "stream must not be tried on 4xx");
+    assert_eq!(
+        saw_stream.load(Ordering::SeqCst),
+        0,
+        "stream must not be tried on 4xx"
+    );
     assert_eq!(saw_non_stream.load(Ordering::SeqCst), 1);
 }
 
@@ -315,8 +319,7 @@ async fn openai_handles_sse_on_2xx_when_stream_false() {
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(sse.as_bytes().to_vec(), "text/event-stream"),
+            ResponseTemplate::new(200).set_body_raw(sse.as_bytes().to_vec(), "text/event-stream"),
         )
         .mount(&server)
         .await;
@@ -341,8 +344,7 @@ async fn anthropic_handles_sse_on_2xx_when_stream_false() {
     Mock::given(method("POST"))
         .and(path("/messages"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(sse.as_bytes().to_vec(), "text/event-stream"),
+            ResponseTemplate::new(200).set_body_raw(sse.as_bytes().to_vec(), "text/event-stream"),
         )
         .mount(&server)
         .await;

--- a/crates/contribai-rs/tests/llm_sse_fallback.rs
+++ b/crates/contribai-rs/tests/llm_sse_fallback.rs
@@ -1,0 +1,205 @@
+//! SSE streaming fallback for OpenAI & Anthropic chat.
+//!
+//! Verifies the two paths added in `llm/provider.rs`:
+//!   1. Non-stream returns 5xx → retry with `stream: true`, parse SSE → Ok(text).
+//!   2. Non-stream returns 4xx → bubble up, no fallback.
+
+use contribai::core::config::LlmConfig;
+use contribai::llm::provider::{
+    create_llm_provider_raw, AnthropicProvider, ChatMessage, LlmProvider, OpenAIProvider,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+fn cfg(provider: &str, base_url: &str) -> LlmConfig {
+    LlmConfig {
+        provider: provider.into(),
+        api_key: "test-key".into(),
+        model: "test-model".into(),
+        temperature: 0.0,
+        max_tokens: 64,
+        base_url: Some(base_url.into()),
+        vertex_project: String::new(),
+        vertex_location: "global".into(),
+        cache_enabled: false,
+        cache_ttl_days: 7,
+        small_model: None,
+        copilot: false,
+        fallback: vec![],
+    }
+}
+
+/// Responder that branches on whether the request body has `"stream": true`.
+struct StreamAware {
+    non_stream: ResponseTemplate,
+    streaming: ResponseTemplate,
+    saw_stream: Arc<AtomicUsize>,
+    saw_non_stream: Arc<AtomicUsize>,
+}
+
+impl Respond for StreamAware {
+    fn respond(&self, req: &Request) -> ResponseTemplate {
+        let body: serde_json::Value =
+            serde_json::from_slice(&req.body).unwrap_or(serde_json::Value::Null);
+        if body["stream"].as_bool() == Some(true) {
+            self.saw_stream.fetch_add(1, Ordering::SeqCst);
+            self.streaming.clone()
+        } else {
+            self.saw_non_stream.fetch_add(1, Ordering::SeqCst);
+            self.non_stream.clone()
+        }
+    }
+}
+
+// ── OpenAI ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn openai_falls_back_to_sse_on_5xx() {
+    let server = MockServer::start().await;
+
+    let sse = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n\
+               data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n\
+               data: [DONE]\n\n";
+
+    let saw_stream = Arc::new(AtomicUsize::new(0));
+    let saw_non_stream = Arc::new(AtomicUsize::new(0));
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header("Authorization", "Bearer test-key"))
+        .respond_with(StreamAware {
+            non_stream: ResponseTemplate::new(503).set_body_string("upstream down"),
+            streaming: ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse),
+            saw_stream: saw_stream.clone(),
+            saw_non_stream: saw_non_stream.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let provider = OpenAIProvider::new(&cfg("openai", &server.uri())).unwrap();
+    let out = provider
+        .chat(&[ChatMessage::user("hi")], None, None, None)
+        .await
+        .expect("SSE fallback should succeed");
+
+    assert_eq!(out, "Hello world");
+    assert_eq!(saw_non_stream.load(Ordering::SeqCst), 1);
+    assert_eq!(saw_stream.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn openai_does_not_fallback_on_4xx() {
+    let server = MockServer::start().await;
+
+    let saw_stream = Arc::new(AtomicUsize::new(0));
+    let saw_non_stream = Arc::new(AtomicUsize::new(0));
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(StreamAware {
+            non_stream: ResponseTemplate::new(400)
+                .set_body_json(serde_json::json!({ "error": { "message": "bad input" }})),
+            streaming: ResponseTemplate::new(500), // should never be hit
+            saw_stream: saw_stream.clone(),
+            saw_non_stream: saw_non_stream.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let provider = OpenAIProvider::new(&cfg("openai", &server.uri())).unwrap();
+    let err = provider
+        .chat(&[ChatMessage::user("hi")], None, None, None)
+        .await
+        .expect_err("4xx must not trigger SSE fallback");
+
+    let msg = err.to_string();
+    assert!(msg.contains("400"), "got: {}", msg);
+    assert!(msg.contains("bad input"), "got: {}", msg);
+    assert_eq!(saw_stream.load(Ordering::SeqCst), 0, "stream must not be tried on 4xx");
+    assert_eq!(saw_non_stream.load(Ordering::SeqCst), 1);
+}
+
+// ── Anthropic ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn anthropic_falls_back_to_sse_on_5xx() {
+    let server = MockServer::start().await;
+
+    let sse = "event: content_block_delta\n\
+               data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\n\n\
+               event: content_block_delta\n\
+               data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\" there\"}}\n\n\
+               event: message_stop\n\
+               data: {\"type\":\"message_stop\"}\n\n";
+
+    let saw_stream = Arc::new(AtomicUsize::new(0));
+    let saw_non_stream = Arc::new(AtomicUsize::new(0));
+
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("anthropic-version", "2023-06-01"))
+        .respond_with(StreamAware {
+            non_stream: ResponseTemplate::new(502).set_body_string("bad gateway"),
+            streaming: ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse),
+            saw_stream: saw_stream.clone(),
+            saw_non_stream: saw_non_stream.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(&cfg("anthropic", &server.uri())).unwrap();
+    let out = provider
+        .chat(&[ChatMessage::user("hi")], Some("be terse"), None, None)
+        .await
+        .expect("SSE fallback should succeed");
+
+    assert_eq!(out, "Hi there");
+    assert_eq!(saw_non_stream.load(Ordering::SeqCst), 1);
+    assert_eq!(saw_stream.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn anthropic_does_not_fallback_on_4xx() {
+    let server = MockServer::start().await;
+
+    let saw_stream = Arc::new(AtomicUsize::new(0));
+    let saw_non_stream = Arc::new(AtomicUsize::new(0));
+
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(StreamAware {
+            non_stream: ResponseTemplate::new(401)
+                .set_body_json(serde_json::json!({ "error": { "message": "invalid key" }})),
+            streaming: ResponseTemplate::new(500),
+            saw_stream: saw_stream.clone(),
+            saw_non_stream: saw_non_stream.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(&cfg("anthropic", &server.uri())).unwrap();
+    let err = provider
+        .chat(&[ChatMessage::user("hi")], None, None, None)
+        .await
+        .expect_err("4xx must not trigger SSE fallback");
+
+    let msg = err.to_string();
+    assert!(msg.contains("401"), "got: {}", msg);
+    assert!(msg.contains("invalid key"), "got: {}", msg);
+    assert_eq!(saw_stream.load(Ordering::SeqCst), 0);
+    assert_eq!(saw_non_stream.load(Ordering::SeqCst), 1);
+}
+
+// Sanity: the public factory still wires the providers used above.
+#[tokio::test]
+async fn factory_creates_openai_and_anthropic() {
+    assert!(create_llm_provider_raw(&cfg("openai", "http://example.invalid")).is_ok());
+    assert!(create_llm_provider_raw(&cfg("anthropic", "http://example.invalid")).is_ok());
+}


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->

## Type
- [ ] `feat` – New feature
- [ ] `fix` – Bug fix
- [ ] `refactor` – Code restructuring
- [ ] `docs` – Documentation
- [ ] `test` – Tests
- [ ] `perf` – Performance
- [ ] `chore` – Maintenance

## Changes
<!-- List the key changes made -->

## Architecture Area
<!-- Which v2.5.0 component does this touch? -->
- [ ] Middleware chain (`core/middleware.py`)
- [ ] Analysis / Skills (`analysis/analyzer.py`, `analysis/skills.py`)
- [ ] Sub-agents (`agents/registry.py`)
- [ ] Tools (`tools/protocol.py`)
- [ ] Memory / Learning (`orchestrator/memory.py`)
- [ ] PR Patrol (`pr/patrol.py`)
- [ ] Pipeline (`orchestrator/pipeline.py`)
- [ ] Other: <!-- specify -->

## Pre-submit Checklist

> **⚠️ CI will auto-run on your PR. Please verify locally before pushing.**

- [ ] `ruff check contribai/` passes (lint)
- [ ] `ruff format --check contribai/ tests/` passes (format)
- [ ] `pytest tests/ -v` passes (356+ tests)
- [ ] Code follows project conventions (async, type hints, Google docstrings)
- [ ] `from __future__ import annotations` at top of new files
- [ ] No hardcoded secrets
- [ ] DCO signoff on all commits (`git commit -s`)

## Related Issues
<!-- Closes #123 -->
