### PR TITLE
fix(installer): correct release URLs and verify SHA256

### DIFF
--- a/crates/contribai-rs/src/pr/patrol.rs
+++ b/crates/contribai-rs/src/pr/patrol.rs
@@ -541,7 +541,7 @@ impl<'a> PrPatrol<'a> {
                 .ok();
             let commit_msg = format!(
                 "fix: address review feedback — {}",
-                &feedback.body.chars().take(60).collect::<String>()
+                feedback.body.chars().take(60).collect::<String>()
             );
 
             let signoff = self.user.as_ref().and_then(PrPatrol::build_signoff);
@@ -609,7 +609,7 @@ impl<'a> PrPatrol<'a> {
              Question from @{}:\n> {}\n\n\
              Write a concise, helpful reply (2-4 sentences).",
             pr_title,
-            &pr_body.chars().take(2000).collect::<String>(),
+            pr_body.chars().take(2000).collect::<String>(),
             feedback.author,
             feedback.body
         );

--- a/install.ps1
+++ b/install.ps1
@@ -1,16 +1,34 @@
 ﻿$Version = "v6.8.0"
+$ErrorActionPreference = "Stop"
 $Repo = "tang-vu/ContribAI"
-$Binary = "contribai-windows-x86_64.exe"
+$Binary = "contribai-$Version-windows-x86_64.exe"
+$ExpectedSha256 = "7450ac2fe313193fd68c313ac3b736c86bb4ddbe3df59334ef4ee56f4f4013a2"
 $InstallDir = "$env:USERPROFILE\.contribai\bin"
 $Url = "https://github.com/$Repo/releases/download/$Version/$Binary"
 
 Write-Host "Installing ContribAI $Version for Windows..." -ForegroundColor Cyan
-Write-Host "  Downloading: $Url"
-
-if (-not (Test-Path $InstallDir)) { New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null }
-
 $OutPath = Join-Path $InstallDir "contribai.exe"
-Invoke-WebRequest -Uri $Url -OutFile $OutPath -UseBasicParsing
+$TempPath = Join-Path ([IO.Path]::GetTempPath()) "contribai-$([Guid]::NewGuid()).tmp"
+
+try {
+    Write-Host "  Downloading: $Url"
+    Invoke-WebRequest -Uri $Url -OutFile $TempPath -UseBasicParsing
+
+    $ActualSha256 = (Get-FileHash -Path $TempPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($ActualSha256 -ne $ExpectedSha256) {
+        throw "Checksum verification failed; refusing to install. Expected $ExpectedSha256, got $ActualSha256."
+    }
+    Write-Host "  SHA256 checksum verified." -ForegroundColor Green
+
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+    Move-Item -Path $TempPath -Destination $OutPath -Force
+} finally {
+    if (Test-Path $TempPath) {
+        Remove-Item -LiteralPath $TempPath -Force
+    }
+}
 
 # Add to user PATH if not already there
 $UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
-﻿#!/bin/bash
-set -e
+#!/bin/bash
+set -euo pipefail
 
 VERSION="v6.8.0"
 REPO="tang-vu/ContribAI"
@@ -10,11 +10,25 @@ OS=$(uname -s | tr "[:upper:]" "[:lower:]")
 ARCH=$(uname -m)
 
 case "$OS" in
-  linux)  BINARY="contribai-linux-x86_64" ;;
+  linux)
+    case "$ARCH" in
+      x86_64|amd64)
+        BINARY="contribai-$VERSION-linux-x86_64"
+        EXPECTED_SHA256="23fad535c931211bab67e3675bd5f67df4603f13f376984e6477a63e3f59ea43"
+        ;;
+      *) echo "Unsupported Linux architecture: $ARCH"; exit 1 ;;
+    esac ;;
   darwin)
     case "$ARCH" in
-      arm64|aarch64) BINARY="contribai-macos-aarch64" ;;
-      *)             BINARY="contribai-macos-x86_64" ;;
+      arm64|aarch64)
+        BINARY="contribai-$VERSION-macos-aarch64"
+        EXPECTED_SHA256="bd20e72b945a4f1d59d7d7305b2ce2e8d17f2199d666bd8bfbe649418431e737"
+        ;;
+      x86_64|amd64)
+        BINARY="contribai-$VERSION-macos-x86_64"
+        EXPECTED_SHA256="bfd5a92d6492f75b80164402d0acca52af395d61c246b31f4f6905a4ee5e928e"
+        ;;
+      *) echo "Unsupported macOS architecture: $ARCH"; exit 1 ;;
     esac ;;
   *) echo "Unsupported OS: $OS"; exit 1 ;;
 esac
@@ -27,14 +41,35 @@ echo "  Binary: $BINARY"
 echo "  Downloading from: $URL"
 echo ""
 
-curl -fsSL "$URL" -o contribai
-chmod +x contribai
+TEMP_FILE=$(mktemp "${TMPDIR:-/tmp}/contribai.XXXXXX")
+trap 'rm -f "$TEMP_FILE"' EXIT
+
+curl -fsSL "$URL" -o "$TEMP_FILE"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL_SHA256=$(sha256sum "$TEMP_FILE" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL_SHA256=$(shasum -a 256 "$TEMP_FILE" | awk '{print $1}')
+else
+  echo "Cannot verify download: sha256sum or shasum is required." >&2
+  exit 1
+fi
+
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+  echo "Checksum verification failed; refusing to install." >&2
+  echo "  Expected: $EXPECTED_SHA256" >&2
+  echo "  Actual:   $ACTUAL_SHA256" >&2
+  exit 1
+fi
+
+echo "  SHA256 checksum verified."
+chmod +x "$TEMP_FILE"
 
 if [ -w "$INSTALL_DIR" ]; then
-  mv contribai "$INSTALL_DIR/contribai"
+  mv "$TEMP_FILE" "$INSTALL_DIR/contribai"
 else
   echo "Need sudo to install to $INSTALL_DIR"
-  sudo mv contribai "$INSTALL_DIR/contribai"
+  sudo mv "$TEMP_FILE" "$INSTALL_DIR/contribai"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- include the release version in Linux, macOS, and Windows asset names
- pin and verify GitHub-published SHA-256 digests before installation
- download to a temporary file and fail closed on mismatch
- reject unsupported Unix architectures instead of downloading an incompatible binary
- remove two redundant formatting borrows that fail on current Rust 1.97 Clippy and block CI on main

## Validation
- Bash syntax check with bash -n install.sh
- PowerShell AST parse check
- verified all four pinned digests against GitHub Release metadata
- verified all four release asset URLs return content
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test patrol (12 patrol tests passed)

Fixes #39
Fixes #40