### PR TITLE
fix(install): select published releases with explicit version pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,19 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - name: Validate publishable package
         run: cargo package -p contribai --locked --allow-dirty
+
+  installer-tests:
+    name: Installer behavior (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Exercise installers with isolated downloads
+        run: node --test scripts/test-installers.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,7 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ github.ref_name }}
+          CONTRIBAI_VERSION: ${{ github.ref_name }}
           CONTRIBAI_INSTALL_DIR: ${{ runner.temp }}/contribai-bin
         run: |
           bash ./install.sh
@@ -176,6 +177,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         env:
+          CONTRIBAI_VERSION: ${{ github.ref_name }}
           CONTRIBAI_INSTALL_DIR: ${{ runner.temp }}\contribai-bin
           CONTRIBAI_NO_PATH_UPDATE: "1"
           RELEASE_TAG: ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Verify the full retained admission audit chain in the same write transaction as each append.
+  Corrupted history and unsupported record schemas block new receipts and approved submissions.
+- Omit stored payload values from audit parsing errors and document evidence-preserving recovery.
+
 ## [6.10.0] - 2026-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Install the latest published stable release by default so a candidate on main cannot break installs.
+- Support exact release pins through `CONTRIBAI_VERSION`; release smoke tests pin their own tag.
+- Use Bash in installation examples and preserve literal Windows installation paths.
+- Exercise installer failure handling and binary preservation in isolated cross-platform tests.
+
 ### Security
 - Verify the full retained admission audit chain in the same write transaction as each append.
   Corrupted history and unsupported record schemas block new receipts and approved submissions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.10.1] - 2026-09-08
+
 ### Security
 - Verify the full retained admission audit chain in the same write transaction as each append.
   Corrupted history and unsupported record schemas block new receipts and approved submissions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "contribai"
-version = "6.10.0"
+version = "6.10.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ failed, cross-repository, scope-mismatched, or fingerprint-mismatched capsules a
 maintainer consent. It remains a local audit receipt, not a substitute for CI, code review,
 provenance attestation, or maintainer judgment.
 
-Every terminal admission attempt is also appended to the local admission audit ledger. Records
+ContribAI attempts to append every terminal admission decision to the local audit ledger. Records
 contain the candidate fingerprint, permit/base SHA when available, scope, checks, decision stage,
 and reason—never generated file contents. Each record's SHA-256 receipt binds the preceding receipt,
 so accidental edits or broken ordering are detectable when the complete local chain is verified:
@@ -233,6 +233,8 @@ contribai admissions --json
 
 The hash chain is a local integrity check, not a signature or remote attestation. An approved
 submission fails closed if its audit decision cannot be persisted.
+Each append verifies the retained history in the same write transaction; corrupted history blocks
+new receipts. See [audit recovery](docs/AUDIT_RECOVERY.md) for preserving and restoring evidence.
 
 ## Capabilities
 
@@ -332,7 +334,7 @@ node --test scripts/check-release-assets.test.mjs
 (cd examples/quickstart-repository && npm test)
 ```
 
-The current workspace runs **696 passing tests** plus one intentionally ignored doctest.
+The current workspace runs **700 passing tests** plus one intentionally ignored doctest.
 
 See the [current phased delivery roadmap](docs/project-roadmap.md) for release gates and upcoming work.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [the threat model](docs/THREAT_MODEL.md) and
 ### Install a release
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tang-vu/ContribAI/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/tang-vu/ContribAI/main/install.sh | bash
 ```
 
 On Windows PowerShell:
@@ -109,8 +109,10 @@ On Windows PowerShell:
 irm https://raw.githubusercontent.com/tang-vu/ContribAI/main/install.ps1 | iex
 ```
 
-The installers verify the release checksum. Their isolated install path is smoke-tested against the
-published binary on Linux, macOS, and Windows for every release.
+The installers select the latest published stable release and verify its checksum.
+Set `CONTRIBAI_VERSION` to an exact tag (for example, `v6.10.0`) to pin a release.
+See [installation options](docs/QUICKSTART.md#installation-options) for platform commands.
+The isolated install path is smoke-tested against the published binary on Linux, macOS, and Windows for every release.
 
 ### Build from source
 

--- a/crates/contribai-rs/Cargo.toml
+++ b/crates/contribai-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contribai"
-version = "6.10.0"
+version = "6.10.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["tang-vu <tang.vu@contribai.dev>"]

--- a/crates/contribai-rs/src/orchestrator/memory.rs
+++ b/crates/contribai-rs/src/orchestrator/memory.rs
@@ -5,7 +5,7 @@
 //! and working memory with TTL.
 
 use chrono::{Duration, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use serde_json;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -457,15 +457,20 @@ impl Memory {
 
     // ── Admission audit ──────────────────────────────────────────────────
 
-    /// Append one terminal admission decision to the integrity-linked local ledger.
+    /// Verify the retained ledger and append a terminal decision in one write transaction.
     pub fn record_admission_audit(
         &self,
         record: AdmissionAuditRecord,
     ) -> Result<AdmissionAuditRecord> {
         let mut db = self.lock_db()?;
         let transaction = db
-            .transaction()
+            .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(|error| ContribError::Database(format!("Admission audit begin: {error}")))?;
+        if !Self::verify_admission_audit_chain_in(&transaction)?.valid {
+            return Err(ContribError::Database(
+                "Admission audit integrity check failed; preserve the database and follow docs/AUDIT_RECOVERY.md before submitting".into(),
+            ));
+        }
         let previous_receipt = transaction
             .query_row(
                 "SELECT receipt FROM admission_audit ORDER BY id DESC LIMIT 1",
@@ -479,6 +484,11 @@ impl Memory {
         let sealed = record.seal(previous_receipt).map_err(|error| {
             ContribError::Database(format!("Admission audit receipt encoding: {error}"))
         })?;
+        if !sealed.verify_receipt() {
+            return Err(ContribError::Database(
+                "Admission audit record uses an unsupported schema".into(),
+            ));
+        }
         let payload = serde_json::to_string(&sealed).map_err(|error| {
             ContribError::Database(format!("Admission audit payload encoding: {error}"))
         })?;
@@ -532,9 +542,8 @@ impl Memory {
         for payload in payloads {
             let payload = payload
                 .map_err(|error| ContribError::Database(format!("Admission audit row: {error}")))?;
-            let record = serde_json::from_str(&payload).map_err(|error| {
-                ContribError::Database(format!("Admission audit payload is invalid: {error}"))
-            })?;
+            let record = serde_json::from_str(&payload)
+                .map_err(|_| ContribError::Database("Admission audit payload is invalid".into()))?;
             records.push(record);
         }
         Ok(records)
@@ -543,6 +552,10 @@ impl Memory {
     /// Verify receipt hashes and predecessor links for the complete local ledger.
     pub fn verify_admission_audit_chain(&self) -> Result<AdmissionAuditVerification> {
         let db = self.lock_db()?;
+        Self::verify_admission_audit_chain_in(&db)
+    }
+
+    fn verify_admission_audit_chain_in(db: &Connection) -> Result<AdmissionAuditVerification> {
         let mut statement = db
             .prepare(
                 "SELECT payload, receipt, previous_receipt, repository, decision, stage, recorded_at
@@ -573,10 +586,8 @@ impl Memory {
                 stored.map_err(|error| {
                     ContribError::Database(format!("Admission audit verification row: {error}"))
                 })?;
-            let record: AdmissionAuditRecord = serde_json::from_str(&payload).map_err(|error| {
-                ContribError::Database(format!(
-                    "Admission audit verification payload is invalid: {error}"
-                ))
+            let record: AdmissionAuditRecord = serde_json::from_str(&payload).map_err(|_| {
+                ContribError::Database("Admission audit verification payload is invalid".into())
             })?;
             records_checked += 1;
             let columns_match = record.receipt == receipt
@@ -1571,6 +1582,115 @@ mod tests {
         let verification = mem.verify_admission_audit_chain().unwrap();
         assert!(!verification.valid);
         assert_eq!(verification.records_checked, 1);
+    }
+
+    fn audit_payloads(mem: &Memory) -> Vec<String> {
+        let db = mem.lock_db().unwrap();
+        let mut query = db
+            .prepare("SELECT payload FROM admission_audit ORDER BY id")
+            .unwrap();
+        query
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap()
+    }
+
+    #[test]
+    fn admission_audit_append_rejects_corruption_anywhere_in_history() {
+        for mutation in [
+            "UPDATE admission_audit SET payload = replace(payload, 'test decision', 'modified') WHERE id = 1",
+            "UPDATE admission_audit SET decision = 'blocked' WHERE id = 1",
+            "DELETE FROM admission_audit WHERE id = 2",
+        ] {
+            let mem = test_memory();
+            for _ in 0..3 {
+                mem.record_admission_audit(audit_record(
+                    "owner/repo",
+                    AdmissionAuditDecision::Approved,
+                ))
+                .unwrap();
+            }
+            mem.lock_db().unwrap().execute(mutation, []).unwrap();
+            let before = audit_payloads(&mem);
+            let error = mem
+                .record_admission_audit(audit_record("owner/repo", AdmissionAuditDecision::Approved))
+                .unwrap_err();
+            assert!(error.to_string().contains("integrity check failed"));
+            assert_eq!(audit_payloads(&mem), before, "must preserve damaged history");
+            assert!(!mem.verify_admission_audit_chain().unwrap().valid);
+        }
+    }
+
+    #[test]
+    fn admission_audit_invalid_payload_errors_do_not_expose_stored_values() {
+        let mem = test_memory();
+        mem.record_admission_audit(audit_record("owner/repo", AdmissionAuditDecision::Approved))
+            .unwrap();
+        let sensitive_value = "private-repository-content-must-not-be-logged";
+        let mut payload: serde_json::Value =
+            serde_json::from_str(&audit_payloads(&mem)[0]).unwrap();
+        payload["decision"] = sensitive_value.into();
+        mem.lock_db()
+            .unwrap()
+            .execute(
+                "UPDATE admission_audit SET payload = ?1",
+                params![payload.to_string()],
+            )
+            .unwrap();
+        let before = audit_payloads(&mem);
+        for result in [
+            mem.verify_admission_audit_chain().map(|_| ()),
+            mem.get_admission_audits(None, None, 10).map(|_| ()),
+            mem.record_admission_audit(audit_record(
+                "owner/repo",
+                AdmissionAuditDecision::Approved,
+            ))
+            .map(|_| ()),
+        ] {
+            let error = result.unwrap_err().to_string();
+            assert!(error.contains("payload is invalid"));
+            assert!(!error.contains(sensitive_value));
+        }
+        assert_eq!(audit_payloads(&mem), before);
+    }
+
+    #[test]
+    fn admission_audit_rejects_unsupported_new_record_schema() {
+        let mem = test_memory();
+        let mut record = audit_record("owner/repo", AdmissionAuditDecision::Approved);
+        record.schema_version = 99;
+        assert!(mem.record_admission_audit(record).is_err());
+        assert!(audit_payloads(&mem).is_empty());
+        assert!(mem.verify_admission_audit_chain().unwrap().valid);
+    }
+
+    #[test]
+    fn admission_audit_concurrent_connections_preserve_one_chain() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("audit.db");
+        let connections = [Memory::open(&path).unwrap(), Memory::open(&path).unwrap()];
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let writers = connections.map(|mem| {
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..4 {
+                    mem.record_admission_audit(audit_record(
+                        "owner/repo",
+                        AdmissionAuditDecision::Approved,
+                    ))
+                    .unwrap();
+                }
+            })
+        });
+        for writer in writers {
+            writer.join().unwrap();
+        }
+        let mem = Memory::open(&path).unwrap();
+        let verified = mem.verify_admission_audit_chain().unwrap();
+        assert!(verified.valid);
+        assert_eq!(verified.records_checked, 8);
     }
 
     // ── Dream consolidation tests ─────────────────────────────────────────

--- a/docs/AUDIT_RECOVERY.md
+++ b/docs/AUDIT_RECOVERY.md
@@ -1,0 +1,63 @@
+# Admission audit recovery
+
+An admission append verifies the complete retained ledger and writes the new receipt in one
+SQLite write transaction. Invalid receipt hashes, broken predecessor links, inconsistent indexed
+fields, malformed payloads, and unsupported schemas prevent new records from being committed.
+An approved submission cannot proceed when that append fails. Existing rows are preserved.
+
+This guard validates retained history. It cannot detect a deleted suffix or an entirely replaced
+database without an independently retained receipt. It does not establish reviewer identity.
+
+## Inspect without submitting
+
+Use the same configuration as the affected process:
+
+```bash
+contribai --config config.yaml admissions --json
+```
+
+The command verifies the complete chain even when filters or a listing limit are supplied. An
+integrity failure returns a non-zero exit status. A malformed payload can prevent JSON output;
+its stored values are intentionally omitted from error messages. Do not interpret missing output
+as an empty, healthy ledger.
+
+Confirm `storage.db_path` in the configuration. The default is `~/.contribai/memory.db`. Opening a
+different or nonexistent database can produce a valid empty ledger, which is not proof that the
+original history is intact. The same database also holds analysis and other operator state.
+
+## Preserve evidence
+
+1. Stop ContribAI CLI runs, web servers, and schedulers that use this database.
+2. Preserve a copy of the database and any remaining `-wal` and `-shm` sidecars after writers have
+   stopped. Keep the originals. A raw copy taken while writers are active is not a reliable backup.
+3. Retain the command's exit status and sanitized error, the ContribAI version, and the last
+   independently saved receipt. Avoid posting the database or its repository metadata publicly.
+
+Do not delete failing rows, recompute historical hashes, or point the process at a new empty
+database merely to obtain a successful check. Those actions destroy or conceal the evidence.
+
+## Restore and verify
+
+Restore a known-good consistent backup to a separate path. Make an operator configuration that
+points `storage.db_path` at that restored copy, then run:
+
+```bash
+contribai --config recovery.yaml admissions --limit 1 --json
+```
+
+Require a successful exit and compare the newest full receipt in `records[0].receipt` with the
+independently retained receipt for that backup. A valid chain alone cannot distinguish an intact
+database from one rolled back to an earlier valid prefix. Account for any decisions made after the
+backup before resuming submissions. Preserve both the damaged database and restoration evidence.
+
+If no trustworthy backup or independent evidence is available, keep external writes disabled and
+investigate the cause with the project maintainers. ContribAI does not automatically repair or
+reset admission history. After restoration, run admission again against current maintainer consent
+and a fresh permit; do not reuse a previously approved candidate's expired evidence.
+
+## Operational limits
+
+Verification reads one retained receipt at a time; it does not collect the full chain in memory.
+Append latency grows with retained history. Writers serialize through SQLite's write transaction.
+A database busy or I/O error fails closed. There is no retention cleanup that silently removes
+receipts to make the check faster.

--- a/docs/CONSENT_PROTOCOL.md
+++ b/docs/CONSENT_PROTOCOL.md
@@ -109,7 +109,7 @@ external policy-engine attestations without treating unsigned v2 receipts as str
 
 ## Admission audit ledger
 
-Every terminal admission attempt appends a content-minimized record to the local SQLite audit
+ContribAI attempts to record every terminal admission decision in the local SQLite audit
 ledger. A record identifies the decision stage and result, candidate fingerprint, repository,
 paths, scope totals, check results, reason, and the permit/base SHA when one was issued. Generated
 file contents are deliberately excluded.
@@ -127,6 +127,11 @@ The web surface exposes `GET /api/admissions` under the server's loopback/API-ke
 default MCP surface exposes the read-only `list_admission_audit` tool. Prometheus reports aggregate
 terminal decisions without repository or path labels. An approved candidate cannot proceed if its
 audit record fails to persist.
+
+Before appending a decision, the full retained chain is verified in the same SQLite write
+transaction. Corrupted history or an unsupported record schema prevents the append, preserving
+the stored evidence and blocking approved submissions. See [audit recovery](AUDIT_RECOVERY.md)
+for inspection and restoration steps. Payload parsing errors never include the stored values.
 
 The linked receipts detect accidental field mutation, deletion in the middle of a retained chain,
 and reordering. They are not signatures, do not establish reviewer identity, and cannot detect an

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -7,7 +7,7 @@ GitHub token, or allow any network request. It does not generate or publish a co
 
 Use a release installer:
 
-    curl -fsSL https://raw.githubusercontent.com/tang-vu/ContribAI/main/install.sh | sh
+    curl -fsSL https://raw.githubusercontent.com/tang-vu/ContribAI/main/install.sh | bash
 
 On Windows PowerShell:
 
@@ -88,3 +88,33 @@ Then inspect consent on a repository you control or one whose maintainer already
 Neither command grants submission capability. A real draft proposal additionally requires explicit
 <code>--submit</code>, current maintainer consent, an exact base SHA, bounded scope, passing checks,
 evidence, and interactive human review.
+
+## Installation options
+
+Installers select GitHub's latest published stable release, independently of the version on `main`.
+Linux and macOS require Bash, curl, and either sha256sum or shasum. Windows supports Windows
+PowerShell 5.1 and PowerShell 7. Published binaries target Linux x86_64, Windows x86_64,
+macOS Intel, and macOS Apple Silicon; other targets require a source build.
+
+To pin an existing stable release on Linux or macOS:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/tang-vu/ContribAI/main/install.sh | CONTRIBAI_VERSION=v6.10.0 bash
+```
+
+On Windows:
+
+```powershell
+$env:CONTRIBAI_VERSION = 'v6.10.0'
+irm https://raw.githubusercontent.com/tang-vu/ContribAI/main/install.ps1 | iex
+Remove-Item Env:CONTRIBAI_VERSION
+```
+
+Pins accept exact stable tags in `vX.Y.Z` form and bypass latest-release lookup. Missing releases,
+lookup failures, and invalid checksums stop installation before replacing an existing binary.
+Set `CONTRIBAI_INSTALL_DIR` for a custom location. On Windows, set `CONTRIBAI_NO_PATH_UPDATE=1`
+when testing an isolated installation; invoke the installed executable by its full path.
+
+The installer and checksums are retrieved over HTTPS from this repository's release infrastructure.
+Checksum verification detects download mismatches; it does not independently establish provenance.
+For provenance verification, see [release artifact verification](RELEASING.md#verify-downloaded-artifacts).

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Start with these documents:
 - [Vercel OSS application](VERCEL_OSS_APPLICATION.md) — evidence-backed application worksheet
 - [Architecture](../ARCHITECTURE.md) — components and trust boundaries
 - [Consent protocol](CONSENT_PROTOCOL.md) — repository opt-in and issue-scoped approval
+- [Audit recovery](AUDIT_RECOVERY.md) — integrity failures, evidence preservation, and restoration
 - [Threat model](THREAT_MODEL.md) — assets, adversaries, mitigations, and residual risk
 - [Security policy](../SECURITY.md) — supported versions and private reporting
 - [Governance](../GOVERNANCE.md) — decision process and project roles

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,8 +7,9 @@ contributions to other repositories. The [product contract](../AGENTS.md) remain
 
 1. Choose a semantic version and describe the user-visible changes, migration requirements,
    safety impact, and known limitations in [CHANGELOG.md](../CHANGELOG.md).
-2. Update the Rust crate version, the `contribai` entry in `Cargo.lock`, and the versions in
-   `install.sh` and `install.ps1` together. Do not update unrelated dependencies during a version bump.
+2. Update the Rust crate version and the `contribai` entry in `Cargo.lock` together. Installers
+   resolve the latest published release by default; release smoke jobs pin `CONTRIBAI_VERSION` to
+   the exact tag. Do not update unrelated dependencies during a version bump.
 3. Review the exact diff. Disclose AI assistance accurately; do not claim a human reviewed or
    verified work unless they did. Preserve existing local user changes outside the release commit.
 4. Run the required checks from the workspace root:
@@ -20,6 +21,7 @@ cargo test --workspace
 cargo build --workspace --release
 cargo audit --deny warnings
 node scripts/check-installers.mjs
+node --test scripts/test-installers.mjs
 node --test scripts/check-release-assets.test.mjs
 node scripts/check-site.mjs
 node --check site/app.js

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -76,6 +76,12 @@ memory, caches, and event logs. Admission records exclude generated file content
 repository names and changed paths. Operators should protect the ContribAI data directory as they
 would source-code metadata.
 
+Admission appends verify all retained receipts and indexed fields in one SQLite write transaction.
+Corruption or malformed payloads prevent appending, and approved submissions fail closed when
+their receipt cannot be recorded. This does not detect suffix truncation or full replacement
+without an independently retained receipt. Audit parsing errors omit stored values. See
+[audit recovery](AUDIT_RECOVERY.md) before restoring or investigating damaged state.
+
 ## Out of scope assumptions
 
 - The operating system and Rust toolchain are not already compromised.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,15 +1,15 @@
 # Current delivery roadmap
 
-Updated: 2026-09-08. Latest published version: v6.9.0. The Rust workspace and
+Updated: 2026-09-08. Latest published version: v6.10.0. The Rust workspace and
 [product contract](../AGENTS.md) govern all phases below.
 
-## Phase 1: Admission evidence (implemented, awaiting release)
+## Phase 1: Admission evidence (released in v6.10.0)
 
 - Integrity-linked local admission ledger and fail-closed persistence for approved submissions.
 - Read-only CLI, authenticated web API, MCP inspection, and decision metrics.
 - Evidence: `8bf9036`, admission and memory tests, and `docs/CONSENT_PROTOCOL.md`.
 
-## Phase 2: Release reliability (in progress)
+## Phase 2: Release reliability (released in v6.10.0)
 
 - Require all four platform builds, workspace tests, and exact-binary offline safety demos
   before a single publishing job uploads the complete release asset set.
@@ -17,20 +17,29 @@ Updated: 2026-09-08. Latest published version: v6.9.0. The Rust workspace and
 - Run the installed release on Linux, Windows, and macOS after publication.
 - Exit evidence: required local checks, green CI for the release commit, successful tagged
   release workflow, all eight binary/checksum assets, and passing installer smoke jobs.
-- Next release candidate: v6.10.0, including the admission ledger and dependency fixes.
-  Do not mark this phase complete until remote release evidence is available.
+- Completed evidence: [candidate CI](https://github.com/tang-vu/ContribAI/actions/runs/34241720698)
+  and [release workflow](https://github.com/tang-vu/ContribAI/actions/runs/34242979684) passed on
+  `1551ed459f8a45e846a18df39f65d55c899db04c`, including all four installer smoke jobs.
+- [v6.10.0 is public](https://github.com/tang-vu/ContribAI/releases/tag/v6.10.0) with eight assets.
+  Downloaded checksums and all four binary attestations were verified against the exact commit,
+  tag, and workflow; the downloaded Windows binary passed its offline safety demo.
 
-## Phase 3: Maintainer operations (planned)
+## Phase 3: Maintainer operations (v6.10.1 candidate)
 
-- Improve audit inspection and actionable failure diagnostics without exposing secrets or
-  generated source content.
-- Document recovery from corrupted local audit state and preserve fail-closed submission.
-- Add regression coverage for consent revocation and exact-candidate review boundaries where
-  review identifies gaps; ship a separately verified release.
+- Verify retained audit history inside each append transaction and provide failure diagnostics
+  without exposing stored payload values.
+- Preserve damaged audit state, reject unsupported schemas, and document recovery while keeping
+  approved submissions fail-closed.
+- Regression coverage includes earlier-row tampering, deleted records, malformed payloads, and
+  concurrent writers. Existing consent-revocation and exact-candidate checks continue to pass.
+- [PR #53](https://github.com/tang-vu/ContribAI/pull/53) tracks this phase. The implementation passed
+  700 local tests and cross-platform CI; versioned release verification remains in progress.
 
 ## Phase 4: Adoption and support (planned)
 
 - Reconcile operator documentation with the current CLI and safe configuration defaults.
+- Ensure ordinary installers target a published release while a newer candidate is still building;
+  retain an explicit version pin for reproducible installs and release smoke tests.
 - Exercise the documented onboarding path from clean installs on supported platforms.
 - Publish a support and compatibility matrix backed by CI evidence.
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,9 +1,29 @@
 [CmdletBinding()]
 param()
 
-$Version = "v6.10.0"
+$Version = $env:CONTRIBAI_VERSION
 $ErrorActionPreference = "Stop"
 $Repo = "tang-vu/ContribAI"
+if ([string]::IsNullOrEmpty($Version)) {
+    $ReleasePrefix = "https://github.com/$Repo/releases/tag/"
+    try {
+        $LatestResponse = Invoke-WebRequest -Uri "https://github.com/$Repo/releases/latest" -Method Head -MaximumRedirection 5 -TimeoutSec 60 -UseBasicParsing
+        $LatestTarget = if ($PSVersionTable.PSVersion.Major -ge 6) {
+            $LatestResponse.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+        } else {
+            $LatestResponse.BaseResponse.ResponseUri.AbsoluteUri
+        }
+    } catch {
+        throw "Cannot resolve the latest published ContribAI release."
+    }
+    if (-not $LatestTarget -or -not $LatestTarget.StartsWith($ReleasePrefix, [StringComparison]::Ordinal)) {
+        throw "Unexpected latest-release destination; refusing to install."
+    }
+    $Version = $LatestTarget.Substring($ReleasePrefix.Length)
+}
+if ($Version -cnotmatch '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\z') {
+    throw "CONTRIBAI_VERSION must be a release tag such as v6.10.0."
+}
 $Binary = "contribai-$Version-windows-x86_64.exe"
 $InstallDir = if ($env:CONTRIBAI_INSTALL_DIR) {
     $env:CONTRIBAI_INSTALL_DIR
@@ -20,29 +40,37 @@ $ChecksumTempPath = "$TempPath.sha256"
 
 try {
     Write-Host "  Downloading: $Url"
-    Invoke-WebRequest -Uri $Url -OutFile $TempPath -UseBasicParsing
-    Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTempPath -UseBasicParsing
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $TempPath -UseBasicParsing
+    } catch {
+        throw "Release binary download failed."
+    }
+    try {
+        Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumTempPath -UseBasicParsing
+    } catch {
+        throw "Release checksum download failed."
+    }
 
     $ExpectedSha256 = ((Get-Content -LiteralPath $ChecksumTempPath -TotalCount 1) -split '\s+')[0].ToLowerInvariant()
     if ($ExpectedSha256 -notmatch '^[0-9a-f]{64}$') {
         throw "Release checksum is malformed; refusing to install."
     }
 
-    $ActualSha256 = (Get-FileHash -Path $TempPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    $ActualSha256 = (Get-FileHash -LiteralPath $TempPath -Algorithm SHA256).Hash.ToLowerInvariant()
     if ($ActualSha256 -ne $ExpectedSha256) {
         throw "Checksum verification failed; refusing to install. Expected $ExpectedSha256, got $ActualSha256."
     }
     Write-Host "  SHA256 checksum verified." -ForegroundColor Green
 
-    if (-not (Test-Path $InstallDir)) {
+    if (-not (Test-Path -LiteralPath $InstallDir)) {
         New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
     }
-    Move-Item -Path $TempPath -Destination $OutPath -Force
+    Move-Item -LiteralPath $TempPath -Destination $OutPath -Force
 } finally {
-    if (Test-Path $TempPath) {
+    if (Test-Path -LiteralPath $TempPath) {
         Remove-Item -LiteralPath $TempPath -Force
     }
-    if (Test-Path $ChecksumTempPath) {
+    if (Test-Path -LiteralPath $ChecksumTempPath) {
         Remove-Item -LiteralPath $ChecksumTempPath -Force
     }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param()
 
-$Version = "v6.10.0"
+$Version = "v6.10.1"
 $ErrorActionPreference = "Stop"
 $Repo = "tang-vu/ContribAI"
 $Binary = "contribai-$Version-windows-x86_64.exe"

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-VERSION="v6.10.0"
+VERSION="v6.10.1"
 REPO="tang-vu/ContribAI"
 INSTALL_DIR="${CONTRIBAI_INSTALL_DIR:-/usr/local/bin}"
 

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,28 @@
 #!/bin/bash
 set -euo pipefail
 
-VERSION="v6.10.0"
+VERSION="${CONTRIBAI_VERSION:-}"
 REPO="tang-vu/ContribAI"
 INSTALL_DIR="${CONTRIBAI_INSTALL_DIR:-/usr/local/bin}"
+
+# Resolve a public release independently of the version currently on main.
+if [ -z "$VERSION" ]; then
+  RELEASE_PREFIX="https://github.com/$REPO/releases/tag/"
+  if ! LATEST_TARGET=$(curl -fsSLI --proto '=https' --proto-redir '=https' \
+      --max-redirs 5 --connect-timeout 15 --max-time 60 -o /dev/null \
+      -w '%{url_effective}' "https://github.com/$REPO/releases/latest"); then
+    echo "Cannot resolve the latest published ContribAI release." >&2
+    exit 1
+  fi
+  case "$LATEST_TARGET" in
+    "$RELEASE_PREFIX"*) VERSION="${LATEST_TARGET#"$RELEASE_PREFIX"}" ;;
+    *) echo "Unexpected latest-release destination; refusing to install." >&2; exit 1 ;;
+  esac
+fi
+if [[ ! "$VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "CONTRIBAI_VERSION must be a release tag such as v6.10.0." >&2
+  exit 1
+fi
 
 # Detect OS and arch
 OS=$(uname -s | tr "[:upper:]" "[:lower:]")

--- a/scripts/check-installers.mjs
+++ b/scripts/check-installers.mjs
@@ -28,12 +28,17 @@ assert(
   "workspace lockfile version does not match the crate"
 );
 assert(
-  shellInstaller.includes('VERSION="v' + version + '"'),
-  "install.sh version does not match the crate"
+  shellInstaller.includes('VERSION="${CONTRIBAI_VERSION:-}"') &&
+    powershellInstaller.includes('$Version = $env:CONTRIBAI_VERSION'),
+  "installers must support explicit version pins"
 );
 assert(
-  powershellInstaller.includes('$Version = "v' + version + '"'),
-  "install.ps1 version does not match the crate"
+  shellInstaller.includes('/releases/latest') && powershellInstaller.includes('/releases/latest'),
+  "ordinary installs must resolve a published release"
+);
+assert(
+  (releaseWorkflow.match(/CONTRIBAI_VERSION: \$\{\{ github.ref_name \}\}/g) || []).length === 2,
+  "both installer smoke steps must pin the exact release tag"
 );
 
 for (const asset of [

--- a/scripts/test-installers.mjs
+++ b/scripts/test-installers.mjs
@@ -115,12 +115,20 @@ function runInstaller(t, engine, options = {}) {
     MOCK_FAIL: options.fail || "", MOCK_LOG: log.replaceAll("\\", "/"),
     MOCK_INSTALLER: installer.replaceAll("\\", "/"),
   };
+  // A Windows PowerShell child launched through Node cannot detect a pwsh parent.
+  // Let each engine construct its own module search path instead of inheriting another edition's.
+  if (engine.name !== "bash") {
+    for (const key of Object.keys(env)) {
+      if (key.toLowerCase() === "psmodulepath") delete env[key];
+    }
+  }
   const args = engine.name === "bash" ? [harness.replaceAll("\\", "/")]
     : ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", harness];
   const result = spawnSync(engine.executable, args, { env, encoding: "utf8", timeout: 60000 });
   assert.ifError(result.error);
   if (options.reject) {
     assert.notEqual(result.status, 0, result.stdout);
+    if (options.error) assert(`${result.stdout}${result.stderr}`.includes(options.error), result.stderr || result.stdout);
     assert.deepEqual(readFileSync(installed), oldBytes, "failure must preserve the installed binary");
   } else {
     assert.equal(result.status, 0, result.stderr || result.stdout);
@@ -148,7 +156,7 @@ for (const engine of engines) {
     test(`${engine.name}: ${fail} failure preserves installation`, (t) => runInstaller(t, engine, { fail, reject: true }));
   }
   for (const checksum of ["not-a-checksum", `${"0".repeat(64)}  fixture\n`]) {
-    test(`${engine.name}: reject malformed or mismatched checksum ${checksum.slice(0, 12)}`, (t) => runInstaller(t, engine, { checksum, reject: true }));
+    test(`${engine.name}: reject malformed or mismatched checksum ${checksum.slice(0, 12)}`, (t) => runInstaller(t, engine, { checksum, reject: true, error: checksum === "not-a-checksum" ? "Release checksum is malformed" : "Checksum verification failed" }));
   }
 }
 for (const platform of ["macos-x86_64", "macos-aarch64"]) {

--- a/scripts/test-installers.mjs
+++ b/scripts/test-installers.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const releaseBase = "https://github.com/tang-vu/ContribAI/releases/";
+const bytes = Buffer.from("verified fixture binary\n");
+const hash = createHash("sha256").update(bytes).digest("hex");
+const oldBytes = Buffer.from("existing installation\n");
+const gitExec = spawnSync("git", ["--exec-path"], { encoding: "utf8" }).stdout?.trim();
+const bash = process.platform === "win32"
+  ? resolve(gitExec, "../../..", "bin/bash.exe") : "bash";
+const engines = [{ name: "bash", executable: bash, script: "install.sh" }];
+if (process.platform === "win32") {
+  engines.push({ name: "powershell", executable: "powershell.exe", script: "install.ps1" });
+  const core = spawnSync("pwsh.exe", ["-NoProfile", "-Command", "exit 0"]);
+  if (!core.error && core.status === 0) {
+    engines.push({ name: "pwsh", executable: "pwsh.exe", script: "install.ps1" });
+  } else if (process.env.CI) {
+    throw new Error("Windows CI must exercise both PowerShell 5.1 and PowerShell 7");
+  }
+}
+
+const bashHarness = `
+set -euo pipefail
+uname() {
+  case "$1" in -s) printf '%s' "$MOCK_OS" ;; -m) printf '%s' "$MOCK_ARCH" ;; esac
+}
+curl() {
+  local output='' url=''
+  while [ "$#" -gt 0 ]; do
+    case "$1" in -o) shift; output="$1" ;; https://*) url="$1" ;; esac
+    shift
+  done
+  printf '%s\\n' "$url" >> "$MOCK_LOG"
+  if [ "$url" = 'https://github.com/tang-vu/ContribAI/releases/latest' ]; then
+    [ "$MOCK_FAIL" != resolve ] || return 22
+    printf '%s' "$MOCK_LATEST"
+  elif [ "$url" = "$MOCK_BINARY_URL" ]; then
+    [ "$MOCK_FAIL" != binary ] || return 22
+    printf '%s' "$MOCK_BINARY" > "$output"
+  elif [ "$url" = "$MOCK_BINARY_URL.sha256" ]; then
+    [ "$MOCK_FAIL" != checksum ] || return 22
+    printf '%s' "$MOCK_CHECKSUM" > "$output"
+  else
+    return 22
+  fi
+}
+source "$MOCK_INSTALLER"
+`;
+
+const powershellHarness = `
+$ErrorActionPreference = 'Stop'
+function Invoke-WebRequest {
+  param([string]$Uri, [string]$OutFile, [string]$Method, [switch]$UseBasicParsing,
+        [int]$MaximumRedirection, [int]$TimeoutSec)
+  Add-Content -LiteralPath $env:MOCK_LOG -Value $Uri -Encoding utf8
+  if ($Uri -eq 'https://github.com/tang-vu/ContribAI/releases/latest') {
+    if ($env:MOCK_FAIL -eq 'resolve') { throw 'PRIVATE_RESPONSE_BODY' }
+    $location = [Uri]$env:MOCK_LATEST
+    return [pscustomobject]@{ BaseResponse = [pscustomobject]@{
+      ResponseUri = $location
+      RequestMessage = [pscustomobject]@{ RequestUri = $location }
+    }}
+  } elseif ($Uri -eq $env:MOCK_BINARY_URL) {
+    if ($env:MOCK_FAIL -eq 'binary') { throw 'PRIVATE_RESPONSE_BODY' }
+    [IO.File]::WriteAllBytes($OutFile, [Convert]::FromBase64String($env:MOCK_BINARY_BASE64))
+  } elseif ($Uri -eq "$env:MOCK_BINARY_URL.sha256") {
+    if ($env:MOCK_FAIL -eq 'checksum') { throw 'PRIVATE_RESPONSE_BODY' }
+    [IO.File]::WriteAllText($OutFile, $env:MOCK_CHECKSUM, [Text.Encoding]::ASCII)
+  } else {
+    throw 'Unexpected network request'
+  }
+}
+& $env:MOCK_INSTALLER
+`;
+
+function runInstaller(t, engine, options = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "contribai-installer-"));
+  t.after(() => {
+    assert.equal(dirname(resolve(directory)), resolve(tmpdir()));
+    rmSync(directory, { recursive: true, force: true });
+  });
+  const bin = join(directory, options.directory || "bin");
+  const temporary = join(directory, "tmp");
+  mkdirSync(bin);
+  mkdirSync(temporary);
+  const installed = join(bin, engine.name === "bash" ? "contribai" : "contribai.exe");
+  writeFileSync(installed, oldBytes);
+  const installer = join(directory, engine.script);
+  writeFileSync(installer, readFileSync(join(root, engine.script), "utf8").replace(/\r\n/g, "\n"));
+  const harness = join(directory, engine.name === "bash" ? "harness.sh" : "harness.ps1");
+  writeFileSync(harness, engine.name === "bash" ? bashHarness : powershellHarness);
+  const version = options.pin || "v7.2.3";
+  const platform = engine.name === "bash" ? (options.platform || "linux-x86_64") : "windows-x86_64.exe";
+  const name = `contribai-${version}-${platform}`;
+  const log = join(directory, "requests.log");
+  const env = {
+    ...process.env,
+    CONTRIBAI_VERSION: options.pin || "",
+    CONTRIBAI_INSTALL_DIR: bin.replaceAll("\\", "/"),
+    CONTRIBAI_NO_PATH_UPDATE: "1",
+    TMPDIR: temporary.replaceAll("\\", "/"), TEMP: temporary, TMP: temporary,
+    MOCK_OS: platform.startsWith("macos") ? "Darwin" : "Linux",
+    MOCK_ARCH: platform.endsWith("aarch64") ? "arm64" : "x86_64",
+    MOCK_BINARY: bytes.toString(), MOCK_BINARY_BASE64: bytes.toString("base64"),
+    MOCK_BINARY_URL: `${releaseBase}download/${version}/${name}`,
+    MOCK_CHECKSUM: options.checksum ?? `${hash}  ${name}\n`,
+    MOCK_LATEST: options.latest || `${releaseBase}tag/v7.2.3`,
+    MOCK_FAIL: options.fail || "", MOCK_LOG: log.replaceAll("\\", "/"),
+    MOCK_INSTALLER: installer.replaceAll("\\", "/"),
+  };
+  const args = engine.name === "bash" ? [harness.replaceAll("\\", "/")]
+    : ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", harness];
+  const result = spawnSync(engine.executable, args, { env, encoding: "utf8", timeout: 60000 });
+  assert.ifError(result.error);
+  if (options.reject) {
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.deepEqual(readFileSync(installed), oldBytes, "failure must preserve the installed binary");
+  } else {
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.deepEqual(readFileSync(installed), bytes);
+  }
+  assert.deepEqual(readdirSync(temporary), [], "temporary downloads must be cleaned up");
+  assert(!`${result.stdout}${result.stderr}`.includes("PRIVATE_RESPONSE_BODY"));
+  const requests = existsSync(log) ? readFileSync(log, "utf8").replace(/^\uFEFF/, "").trim().split(/\r?\n/) : [];
+  if (options.pin) assert(!requests.some((url) => url.endsWith("/latest")));
+  if (!options.reject) assert(requests.includes(env.MOCK_BINARY_URL));
+  if (options.noDownloads) assert(!requests.some((url) => url.includes("/download/")));
+}
+
+for (const engine of engines) {
+  test(`${engine.name}: install into a literal path with spaces and brackets`, (t) => runInstaller(t, engine, { directory: "bin [verified]" }));
+  test(`${engine.name}: install the published release independent of source version`, (t) => runInstaller(t, engine));
+  test(`${engine.name}: explicit version bypasses latest lookup`, (t) => runInstaller(t, engine, { pin: "v6.10.0" }));
+  for (const pin of ["../v6.10.0", "v6.10.0\nextra", "v6.10.0\n", "v01.2.3", "https://other.example/file"]) {
+    test(`${engine.name}: reject invalid pin ${JSON.stringify(pin)}`, (t) => runInstaller(t, engine, { pin, reject: true, noDownloads: true }));
+  }
+  for (const latest of ["https://other.example/releases/tag/v7.2.3", `${releaseBase}tag/v7.2.3-rc.1`, `${releaseBase}tag/v7.2.3?next=bad`]) {
+    test(`${engine.name}: reject unexpected latest destination ${latest}`, (t) => runInstaller(t, engine, { latest, reject: true, noDownloads: true }));
+  }
+  for (const fail of ["resolve", "binary", "checksum"]) {
+    test(`${engine.name}: ${fail} failure preserves installation`, (t) => runInstaller(t, engine, { fail, reject: true }));
+  }
+  for (const checksum of ["not-a-checksum", `${"0".repeat(64)}  fixture\n`]) {
+    test(`${engine.name}: reject malformed or mismatched checksum ${checksum.slice(0, 12)}`, (t) => runInstaller(t, engine, { checksum, reject: true }));
+  }
+}
+for (const platform of ["macos-x86_64", "macos-aarch64"]) {
+  test(`bash: select ${platform}`, (t) => runInstaller(t, engines[0], { platform }));
+}

--- a/site/index.html
+++ b/site/index.html
@@ -299,7 +299,7 @@
             <article class="command-step">
               <div class="command-meta"><span>1</span><strong>Install</strong></div>
               <div class="command-box">
-                <code id="install-command">curl -fsSL https://raw.githubusercontent.com/tang-vu/ContribAI/main/install.sh | sh</code>
+                <code id="install-command">curl -fsSL https://raw.githubusercontent.com/tang-vu/ContribAI/main/install.sh | bash</code>
                 <button class="copy-button" type="button" data-copy="install-command" aria-label="Copy install command">Copy</button>
               </div>
               <details>


### PR DESCRIPTION
Installers currently embed the source version, so a version bump on main can point ordinary users at assets that are not published yet. Resolve the latest published stable release by default and accept an exact CONTRIBAI_VERSION pin; release smoke jobs pin their own tag.

This branch includes and is synchronized with the v6.10.1 candidate in #53; merge after #53. Installer changes preserve checksum verification and reject invalid release destinations or tags before downloading. Failure tests verify preservation of an existing binary, temporary-file cleanup, and sanitized PowerShell errors. Installation examples now invoke Bash explicitly.

Validation: cargo fmt, clippy with warnings denied, all 700 workspace tests, release build, and RustSec audit passed locally. All 34 local installer cases, 10 release-verifier cases, actionlint, website checks, and quickstart fixture passed. A real isolated Windows PowerShell installation selected public v6.10.0, verified its checksum, and passed version/demo checks. All installer behavior jobs passed on Linux, macOS, and Windows, including 50 Windows cases exercising PowerShell 5.1 and 7. The final synchronized commit is c3a8d5975ae57605e3d19f2205847f856ec59eb6; CI https://github.com/tang-vu/ContribAI/actions/runs/34248673044 has passed installer, lint, MSRV, package, and dependency checks, with platform Rust builds still running.

AI assisted implementation and verification. Independent human review has not been recorded. Checksums do not independently establish artifact provenance; latest-release discovery depends on GitHub availability. Product submission and consent defaults are unchanged.
